### PR TITLE
Parse markdown when pasting from clipboard

### DIFF
--- a/src/plugins.js
+++ b/src/plugins.js
@@ -8,6 +8,7 @@ import Prism from "slate-prism";
 import EditList from "./plugins/EditList";
 import KeyboardShortcuts from "./plugins/KeyboardShortcuts";
 import MarkdownShortcuts from "./plugins/MarkdownShortcuts";
+import MarkdownPaste from "./plugins/MarkdownPaste";
 import { insertImageFile } from "./changes";
 
 const createPlugins = () => {
@@ -38,6 +39,7 @@ const createPlugins = () => {
     TrailingBlock({ type: "paragraph" }),
     KeyboardShortcuts(),
     MarkdownShortcuts(),
+    MarkdownPaste(),
   ];
 };
 

--- a/src/plugins/MarkdownPaste.js
+++ b/src/plugins/MarkdownPaste.js
@@ -1,0 +1,19 @@
+// @flow
+import { Change } from "slate";
+import { getEventTransfer } from "slate-react";
+import Markdown from "../serializer";
+
+export default function MarkdownPaste() {
+  return {
+    onPaste(ev: SyntheticKeyboardEvent<*>, change: Change) {
+      const transfer = getEventTransfer(ev);
+      const { text } = transfer;
+      if (transfer.type !== "text" && transfer.type !== "html") return;
+
+      const fragment = Markdown.deserialize(text);
+      change.insertFragment(fragment.document);
+
+      return change;
+    },
+  };
+}


### PR DESCRIPTION
Hey @albinekb – in my testing this works really well, it would be great if you get a chance to take a look before I merge 😄

Because Apple Notes puts things on the clipboard in a mostly compatible format with Markdown I was even able to copy and paste from Notes directly into Outline and have it retain checkbox and other list formatting 🙌 

Closes #4 