### PR TITLE
Use modifier key with escape

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ This callback is triggered when the user explicitly requests to save using a key
 
 #### `onCancel`
 
-This callback is triggered when the escape key is hit within the editor. You may use it to cancel editing.
+This callback is triggered when the `Cmd+Escape` is hit within the editor. You may use it to cancel editing.
 
 #### `onChange`
 

--- a/src/index.js
+++ b/src/index.js
@@ -186,7 +186,7 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
         if (isModKey(ev)) this.onSaveAndExit(ev);
         return;
       case "Escape":
-        this.onCancel(ev);
+        if (isModKey(ev)) this.onCancel(ev);
         return;
       default:
     }


### PR DESCRIPTION
When fixing search toolbar, I realized that hitting escape to cancel changes is pretty darn dangerous and annoying so I think it makes sense to set it up with a modifier key. E.g. I have Escape remapped to Capslock so hitting it to cancel large file changes is dangerous. Another option would be to remove this logic completely and provide callbacks to host application to define the global keyboard shortcuts.