### PR TITLE
Don't require babel-polyfill

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,7 +6,7 @@
     "transform-decorators-legacy",
     "transform-es2015-destructuring",
     "transform-object-rest-spread",
-    "transform-regenerator",
+    "transform-async-to-generator",
     "transform-class-properties"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@tommoor/slate-drop-or-paste-images": "^0.8.1",
+    "babel-plugin-transform-async-to-generator": "^6.24.1",
     "boundless-arrow-key-navigation": "^1.1.0",
     "copy-to-clipboard": "^3.0.8",
     "eslint-plugin-flowtype": "^2.46.1",
@@ -53,7 +54,6 @@
     "babel-plugin-transform-es2015-destructuring": "^6.23.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
-    "babel-plugin-transform-regenerator": "^6.24.1",
     "babel-preset-env": "^1.6.1",
     "babel-preset-flow": "^6.23.0",
     "babel-preset-react": "^6.24.1",
@@ -64,7 +64,6 @@
     "eslint-plugin-react": "^7.7.0",
     "flow-bin": "^0.68.0",
     "prettier": "^1.11.1",
-    "regenerator-runtime": "^0.11.1",
     "webpack": "^4.6.0",
     "webpack-cli": "^2.0.14",
     "webpack-serve": "^0.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5198,7 +5198,7 @@ regenerator-runtime@^0.10.0, regenerator-runtime@^0.10.5:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 
-regenerator-runtime@^0.11.0, regenerator-runtime@^0.11.1:
+regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 


### PR DESCRIPTION
`transform-regenerator` requires regerator runtime or babel polyfill from library user.