### PR TITLE
Dist improvements

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,6 +7,12 @@
     "transform-es2015-destructuring",
     "transform-object-rest-spread",
     "transform-async-to-generator",
-    "transform-class-properties"
+    "transform-class-properties",
+    ["transform-runtime", {
+      "helpers": false,
+      "polyfill": false,
+      "polyfill": false,
+      "regenerator": true
+    }]
   ]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -11,7 +11,6 @@
     ["transform-runtime", {
       "helpers": false,
       "polyfill": false,
-      "polyfill": false,
       "regenerator": true
     }]
   ]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ shortcuts inline and output Markdown.
 import Editor from "rich-markdown-editor";
 
 <Editor
-  defaultValue="Title\n\nBody"
+  defaultValue="Hello world!"
 />
 ```
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@tommoor/slate-drop-or-paste-images": "^0.8.1",
     "babel-plugin-transform-async-to-generator": "^6.24.1",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "boundless-arrow-key-navigation": "^1.1.0",
     "copy-to-clipboard": "^3.0.8",
     "eslint-plugin-flowtype": "^2.46.1",

--- a/src/components/Toolbar/LinkToolbar.js
+++ b/src/components/Toolbar/LinkToolbar.js
@@ -3,7 +3,7 @@ import * as React from "react";
 import { findDOMNode } from "react-dom";
 import { Node } from "slate";
 import { Editor, findDOMNode as slateFindDOMNode } from "slate-react";
-import ArrowKeyNavigation from "boundless-arrow-key-navigation";
+import ArrowKeyNavigation from "boundless-arrow-key-navigation/build";
 import styled from "styled-components";
 import keydown from "react-keydown";
 import { CloseIcon, OpenIcon, TrashIcon } from "outline-icons";

--- a/yarn.lock
+++ b/yarn.lock
@@ -998,6 +998,12 @@ babel-plugin-transform-regenerator@^6.22.0, babel-plugin-transform-regenerator@^
   dependencies:
     regenerator-transform "^0.10.0"
 
+babel-plugin-transform-runtime@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz#88490d446502ea9b8e7efb0fe09ec4d99479b1ee"
+  dependencies:
+    babel-runtime "^6.22.0"
+
 babel-plugin-transform-strict-mode@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz#d5faf7aa578a65bbe591cf5edae04a0c67020758"


### PR DESCRIPTION
Also `transform-async-to-generator` requires regenerator runtime which I missed somehow :( Added runtime plugin to include it and also swapped to using es5 build of the boundless library (it exposes `module` in the `package.json` so non-standard ES6 was used by default). Tested with CRA.