### PR TITLE
Slug without unicode

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "slate-prism": "^0.5.0",
     "slate-react": "^0.12.3",
     "slate-trailing-block": "^0.5.0",
-    "slug": "^0.9.1",
+    "slugify": "^1.3.0",
     "styled-components": "^3.2.3"
   },
   "peerDependencies": {

--- a/src/lib/headingToSlug.js
+++ b/src/lib/headingToSlug.js
@@ -1,15 +1,15 @@
 // @flow
 import { escape } from "lodash";
 import { Document, Block, Node } from "slate";
-import slug from "slug";
+import slugify from "slugify";
 
 // finds the index of this heading in the document compared to other headings
 // with the same slugified text
 function indexOfType(document, heading) {
-  const slugified = escape(slug(heading.text));
+  const slugified = escape(slugify(heading.text));
   const headings = document.nodes.filter((node: Block) => {
     if (!node.text) return false;
-    return node.type.match(/^heading/) && slugified === escape(slug(node.text));
+    return node.type.match(/^heading/) && slugified === escape(slugify(node.text));
   });
 
   return headings.indexOf(heading);
@@ -18,7 +18,7 @@ function indexOfType(document, heading) {
 // calculates a unique slug for this heading based on it's text and position
 // in the document that is as stable as possible
 export default function headingToSlug(document: Document, node: Node) {
-  const slugified = escape(slug(node.text));
+  const slugified = escape(slugify(node.text));
   const index = indexOfType(document, node);
   if (index === 0) return slugified;
   return `${slugified}-${index}`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5685,11 +5685,9 @@ slide@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
 
-slug@^0.9.1:
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/slug/-/slug-0.9.1.tgz#af08f608a7c11516b61778aa800dce84c518cfda"
-  dependencies:
-    unicode ">= 0.3.1"
+slugify@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.3.0.tgz#787919259d28c825fbcae6da2e01c77a109793f6"
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
@@ -6228,10 +6226,6 @@ uid-number@^0.0.6:
 underscore@~1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.6.0.tgz#8b38b10cacdef63337b8b24e4ff86d45aea529a8"
-
-"unicode@>= 0.3.1":
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/unicode/-/unicode-10.0.0.tgz#e5d51c1db93b6c71a0b879e0b0c4af7e6fdf688e"
 
 union-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
`slugify` is a port of `slug` without the unicode package for smaller consumer bundle size without ignoring node modules.