### PR TITLE
Avoid serializing state on every change event. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,11 @@ This callback is triggered when the user explicitly requests to save using a key
 
 This callback is triggered when the `Cmd+Escape` is hit within the editor. You may use it to cancel editing.
 
-#### `onChange`
+#### `onChange(() => value)`
 
 This callback is triggered when the contents of the editor changes, usually due to user input such as a keystroke or using formatting options. You may use this to locally persist the editors state, see the [inbuilt example](/example/index.js).
+
+As of `v4.0.0` this callback returns a function which when called returns the current text value of the document. This optimization is made to avoid serializing the state of the document to text on every change event, allowing the host app to choose when it needs this value.
 
 #### `onImageUploadStart`
 

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from "react";
+import { debounce } from "lodash";
 import ReactDOM from "react-dom";
 import Editor from "../../src";
 
@@ -25,6 +26,10 @@ class Example extends React.Component<*, { readOnly: boolean, dark: boolean }> {
     this.setState({ dark: !this.state.dark });
   };
 
+  handleChange = debounce(value => {
+    localStorage.setItem("saved", value());
+  }, 250);
+
   render() {
     return (
       <div style={{ marginTop: "60px" }}>
@@ -41,7 +46,7 @@ class Example extends React.Component<*, { readOnly: boolean, dark: boolean }> {
           defaultValue={defaultValue}
           onSave={options => console.log("Save triggered", options)}
           onCancel={() => console.log("Cancel triggered")}
-          onChange={text => localStorage.setItem("saved", text)}
+          onChange={this.handleChange}
           onClickLink={href => console.log("Clicked link: ", href)}
           onShowToast={message => window.alert(message)}
           onSearchLink={async term => {

--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,7 @@ type Props = {
   uploadImage?: (file: File) => Promise<string>,
   onSave: ({ done?: boolean }) => *,
   onCancel: () => *,
-  onChange: string => *,
+  onChange: (value: () => string) => *,
   onImageUploadStart: () => *,
   onImageUploadStop: () => *,
   onSearchLink?: (term: string) => Promise<SearchResult[]>,
@@ -118,13 +118,17 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
     this.setState({ editorLoaded: true });
   };
 
+  value = (): string => {
+    return Markdown.serialize(this.state.editorValue);
+  };
+
   handleChange = (change: Change) => {
     if (this.state.editorValue !== change.value) {
-      if (this.props.onChange && !this.props.readOnly) {
-        this.props.onChange(Markdown.serialize(change.value));
-      }
-
-      this.setState({ editorValue: change.value });
+      this.setState({ editorValue: change.value }, state => {
+        if (this.props.onChange && !this.props.readOnly) {
+          this.props.onChange(this.value);
+        }
+      });
     }
   };
 


### PR DESCRIPTION
Big perf increase on large documents – noticeably less lag while typing.

Note: This will require a major version bump as the `onChange` callback signature changes.

Related https://github.com/outline/rich-markdown-editor/issues/29