### PR TITLE
Upgrade Slate

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "react-keydown": "^1.9.7",
     "react-medium-image-zoom": "^3.0.10",
     "react-portal": "^4.1.4",
-    "slate": "^0.34.5",
+    "slate": "^0.36.2",
     "slate-collapse-on-escape": "^0.6.1",
     "slate-edit-code": "^0.15.5",
     "slate-edit-list": "^0.11.3",

--- a/src/schema.js
+++ b/src/schema.js
@@ -1,15 +1,41 @@
 // @flow
 const schema = {
   blocks: {
-    heading1: { nodes: [{ objects: ["text"] }], marks: [""] },
-    heading2: { nodes: [{ objects: ["text"] }], marks: [""] },
-    heading3: { nodes: [{ objects: ["text"] }], marks: [""] },
-    heading4: { nodes: [{ objects: ["text"] }], marks: [""] },
-    heading5: { nodes: [{ objects: ["text"] }], marks: [""] },
-    heading6: { nodes: [{ objects: ["text"] }], marks: [""] },
+    heading1: {
+      nodes: [{ match: { object: "text" } }],
+      marks: [""],
+    },
+    heading2: {
+      nodes: [{ match: { object: "text" } }],
+      marks: [""],
+    },
+    heading3: {
+      nodes: [{ match: { object: "text" } }],
+      marks: [""],
+    },
+    heading4: {
+      nodes: [{ match: { object: "text" } }],
+      marks: [""],
+    },
+    heading5: {
+      nodes: [{ match: { object: "text" } }],
+      marks: [""],
+    },
+    heading6: {
+      nodes: [{ match: { object: "text" } }],
+      marks: [""],
+    },
     "block-quote": { marks: [""] },
     table: {
-      nodes: [{ types: ["table-row", "table-head", "table-cell"] }],
+      nodes: [
+        {
+          match: [
+            { object: ["table-row"] },
+            { object: ["table-head"] },
+            { object: ["table-cell"] },
+          ],
+        },
+      ],
     },
     "horizontal-rule": {
       isVoid: true,
@@ -21,23 +47,23 @@ const schema = {
   document: {
     nodes: [
       {
-        types: [
-          "paragraph",
-          "heading1",
-          "heading2",
-          "heading3",
-          "heading4",
-          "heading5",
-          "heading6",
-          "block-quote",
-          "code",
-          "horizontal-rule",
-          "image",
-          "bulleted-list",
-          "ordered-list",
-          "todo-list",
-          "block-toolbar",
-          "table",
+        match: [
+          { type: "paragraph" },
+          { type: "heading1" },
+          { type: "heading2" },
+          { type: "heading3" },
+          { type: "heading4" },
+          { type: "heading5" },
+          { type: "heading6" },
+          { type: "block-quote" },
+          { type: "code" },
+          { type: "horizontal-rule" },
+          { type: "image" },
+          { type: "bulleted-list" },
+          { type: "ordered-list" },
+          { type: "todo-list" },
+          { type: "block-toolbar" },
+          { type: "table" },
         ],
         min: 1,
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5587,6 +5587,10 @@ slate-dev-logger@^0.1.0, slate-dev-logger@^0.1.39:
   version "0.1.39"
   resolved "https://registry.yarnpkg.com/slate-dev-logger/-/slate-dev-logger-0.1.39.tgz#744a69b85034244713e6de51483af5713c345af4"
 
+slate-dev-logger@^0.1.42:
+  version "0.1.42"
+  resolved "https://registry.yarnpkg.com/slate-dev-logger/-/slate-dev-logger-0.1.42.tgz#922c4693469e6d60deaa10adfd22b627c9632fbf"
+
 slate-edit-code@^0.15.5:
   version "0.15.5"
   resolved "https://registry.yarnpkg.com/slate-edit-code/-/slate-edit-code-0.15.5.tgz#9b64ad7150a6eaaa8212d7a2200e1c6ae2332b63"
@@ -5655,17 +5659,17 @@ slate-react@^0.12.3:
     slate-plain-serializer "^0.5.9"
     slate-prop-types "^0.4.26"
 
-slate-schema-violations@^0.1.18:
-  version "0.1.18"
-  resolved "https://registry.yarnpkg.com/slate-schema-violations/-/slate-schema-violations-0.1.18.tgz#bc760e17dab85a613cd9a5399b98cbf867db0eb7"
+slate-schema-violations@^0.1.24:
+  version "0.1.28"
+  resolved "https://registry.yarnpkg.com/slate-schema-violations/-/slate-schema-violations-0.1.28.tgz#58cd64c3c54680f5e88dc0ca75e93d3a7e41581e"
 
 slate-trailing-block@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/slate-trailing-block/-/slate-trailing-block-0.5.0.tgz#cedb4f2975f1167e0fb9d259ce1252b82f4d74ff"
 
-slate@^0.34.5:
-  version "0.34.5"
-  resolved "https://registry.yarnpkg.com/slate/-/slate-0.34.5.tgz#4bc30dc300c924193d42371a7afcc168676f2798"
+slate@^0.36.2:
+  version "0.36.2"
+  resolved "https://registry.yarnpkg.com/slate/-/slate-0.36.2.tgz#63640fde050aa3b88342c2ffb665bc0e00be6239"
   dependencies:
     debug "^3.1.0"
     direction "^0.1.5"
@@ -5673,8 +5677,8 @@ slate@^0.34.5:
     is-empty "^1.0.0"
     is-plain-object "^2.0.4"
     lodash "^4.17.4"
-    slate-dev-logger "^0.1.39"
-    slate-schema-violations "^0.1.18"
+    slate-dev-logger "^0.1.42"
+    slate-schema-violations "^0.1.24"
     type-of "^2.0.1"
 
 slice-ansi@0.0.4:


### PR DESCRIPTION
There's a different breaking version every couple of weeks it seems, becoming increasingly difficult to stay on top of and various plugins are falling behind 😢 

### Plugins

- [ ] `slate-edit-code` supports [version 0.33](https://github.com/GitbookIO/slate-edit-code/blob/master/package.json#L16)
  - [PR for Slate 0.37](https://github.com/GitbookIO/slate-edit-code/pull/46)
- [ ] `slate-edit-list` supports [version 0.32](https://github.com/GitbookIO/slate-edit-list/blob/master/package.json#L10)
  - [PR for Slate 0.40](https://github.com/GitbookIO/slate-edit-list/pull/83)
- [ ] `slate-prism` supports [version 0.32](https://github.com/GitbookIO/slate-prism/blob/master/package.json#L15)
  - [PR for Slate 0.37](https://github.com/GitbookIO/slate-prism/pull/13)
- [ ] `slate-trailing-block` supports [version 0.32](https://github.com/GitbookIO/slate-trailing-block/blob/master/package.json#L10)
- [x] `slate-paste-linkify` supports [version 0.37](https://github.com/ianstormtaylor/slate-plugins/blob/master/packages/slate-paste-linkify/package.json)