### PR TITLE
remove image after failed upload

### DIFF
--- a/src/changes.js
+++ b/src/changes.js
@@ -85,9 +85,11 @@ export async function insertImageFile(
         data: { src, alt, loading: false },
       };
     } catch (error) {
-      props = {
-        data: { alt, src: placeholderSrc, loading: false, error },
-      };
+      if (editor.props.onShowToast) {
+        editor.props.onShowToast(
+          "Sorry, an error occurred uploading the image"
+        );
+      }
     }
 
     const placeholder = editor.value.document.findDescendant(
@@ -98,9 +100,16 @@ export async function insertImageFile(
     // case we can quietly prevent updating the image.
     if (!placeholder) return;
 
-    editor.change(change => {
-      change.setNodeByKey(placeholder.key, props);
-    });
+    // if there was an error during upload, remove the placeholder image
+    if (!props) {
+      editor.change(change => {
+        change.removeNodeByKey(placeholder.key);
+      });
+    } else {
+      editor.change(change => {
+        change.setNodeByKey(placeholder.key, props);
+      });
+    }
   } catch (err) {
     throw err;
   } finally {

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -35,7 +35,6 @@ class Image extends React.Component<Props, State> {
     const loading = node.data.get("loading");
     const caption = node.data.get("alt") || "";
     const src = node.data.get("src");
-    const error = node.data.get("error");
     const active =
       editor.value.isFocused && editor.value.selection.hasEdgeIn(node);
     const showCaption = !readOnly || caption;
@@ -82,9 +81,6 @@ class Image extends React.Component<Props, State> {
                 disabled={readOnly}
                 tabIndex={-1}
               />
-            )}
-            {error && (
-              <Error>Sorry, an error occurred uploading the image.</Error>
             )}
           </React.Fragment>
         )}


### PR DESCRIPTION
Remove images which fail to upload from the document. An image which
fails to upload will not be available on subsequent document loading and
thus should not continue to appear in the document if it fails to
upload. Keeping the image in the document is misleading to the user
(even with the "sorry failed to upload" overlay).

This change removes the image from the document and shows a toast
message instead.

---
See https://github.com/outline/outline/issues/786 for more context.