### PR TITLE
Add hideToolbars prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ Allows overriding the inbuilt theme to brand the editor, for example use your ow
 
 With `dark` set to `true` the editor will use a default dark theme that's included. See the [source here](/src/theme.js).
 
+#### `hideToolbars`
+
+Prevent toolbars (formatting, link, block, and block insert) from displaying.
+
 
 ### Callbacks
 

--- a/src/index.js
+++ b/src/index.js
@@ -253,6 +253,7 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
       defaultValue,
       autoFocus,
       plugins,
+      hideToolbars,
       ...rest
     } = this.props;
 
@@ -276,11 +277,13 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
               this.state.editorLoaded &&
               this.editor && <Contents editor={this.editor} />}
             {!readOnly &&
-              this.editor && (
+              this.editor &&
+              !hideToolbars && (
                 <Toolbar value={this.state.editorValue} editor={this.editor} />
               )}
             {!readOnly &&
-              this.editor && (
+              this.editor &&
+              !hideToolbars && (
                 <BlockInsert
                   editor={this.editor}
                   onInsertImage={this.insertImageFile}

--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,7 @@ type Props = {
   readOnly?: boolean,
   toc?: boolean,
   dark?: boolean,
+  hideToolbars?: boolean,
   schema?: Schema,
   theme?: Object,
   uploadImage?: (file: File) => Promise<string>,


### PR DESCRIPTION
`hideToolbars` editor prop to prevent toolbars from displaying.  This provides us with a way to create our own formatting toolbars, etc.