### PR TITLE
Make inbuilt renderNode a plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ import { history } from "react-router";
 
 #### `renderNode`
 
-This callback allows overriding of the [inbuilt renderNode](https://github.com/outline/rich-markdown-editor/blob/master/src/nodes.js) – if a component is returned from the callback then it will be used instead of the default implementation. See the [Slate documentation](https://docs.slatejs.org/guides/rendering#nodes-and-marks) for an example.
+See the [Slate documentation](https://docs.slatejs.org/guides/rendering#nodes-and-marks) for an example.  There is an [inbuilt renderNode](https://github.com/outline/rich-markdown-editor/blob/master/src/nodes.js) implemented as a plugin.
 
 #### `getLinkComponent(Node)`
 

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,6 @@ import Contents from "./components/Contents";
 import Markdown from "./serializer";
 import createPlugins from "./plugins";
 import renderMark from "./marks";
-import renderNode from "./nodes";
 import commands from "./commands";
 import queries from "./queries";
 
@@ -43,7 +42,6 @@ type Props = {
   onSearchLink?: (term: string) => Promise<SearchResult[]>,
   onClickLink?: (href: string) => *,
   onShowToast?: (message: string) => *,
-  renderNode?: SlateNodeProps => ?React.Node,
   getLinkComponent?: Node => ?React.ComponentType<*>,
   className?: string,
   style?: Object,
@@ -215,12 +213,6 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
     editor.moveToEndOfDocument().focus();
   };
 
-  renderNode = (...args: *) => {
-    const node = this.props.renderNode && this.props.renderNode(...args);
-    if (node) return node;
-    return renderNode(...args);
-  };
-
   getSchema = () => {
     if (this.prevSchema !== this.props.schema) {
       this.schema = {
@@ -293,7 +285,6 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
               commands={commands}
               queries={queries}
               placeholder={placeholder}
-              renderNode={this.renderNode}
               renderMark={renderMark}
               schema={this.getSchema()}
               onKeyDown={this.handleKeyDown}

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -75,4 +75,4 @@ function renderNode(props: SlateNodeProps, editor: Editor, next: Function) {
   }
 }
 
-export default renderNode;
+export default { renderNode };

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -16,6 +16,7 @@ import MarkdownShortcuts from "./plugins/MarkdownShortcuts";
 import MarkdownPaste from "./plugins/MarkdownPaste";
 import Ellipsis from "./plugins/Ellipsis";
 import Embeds from "./plugins/Embeds";
+import Nodes from "./nodes.js";
 
 // additional language support based on the most popular programming languages
 import "prismjs/components/prism-ruby";
@@ -27,6 +28,7 @@ import "prismjs/components/prism-java";
 
 const createPlugins = ({ placeholder, getLinkComponent }: *) => {
   return [
+    Nodes,
     PasteLinkify({
       type: "link",
       collapseTo: "end",


### PR DESCRIPTION
**Goal:**
Provide the ability to create a custom renderNode with **priority** for specific node types, but then fallback to the inbuilt node for all others.

The current setup forces you to either: 
a) completely override the inbuilt renderNode   
b) have a custom plugin-based renderNode that's secondary to the inbuilt