### PR TITLE
Adds `jpeg` MIME type to the configured extensions image insert.

### DIFF
--- a/src/plugins.js
+++ b/src/plugins.js
@@ -43,7 +43,7 @@ const createPlugins = ({ placeholder, getLinkComponent }: *) => {
       },
     }),
     InsertImages({
-      extensions: ["png", "jpg", "gif", "webp"],
+      extensions: ["png", "jpg", "jpeg", "gif", "webp"],
       insertImage: (editor, file) => editor.insertImageFile(file),
     }),
     EditCode({


### PR DESCRIPTION
Chrome 72 on OSX is reporting the type of dropped .jpg files as `jpeg`,
which means they are not accepted when they should be. I add the `jpeg`
MIME type along with the existing `jpg` type so that all JPG files are
accepted.