### PR TITLE
sync z-index

### DIFF
--- a/src/components/BlockInsert.js
+++ b/src/components/BlockInsert.js
@@ -154,7 +154,7 @@ class BlockInsert extends React.Component<Props, State> {
 
 const Trigger = styled.div`
   position: absolute;
-  z-index: 1;
+  z-index: 200;
   opacity: 0;
   background-color: ${props => props.theme.background};
   transition: opacity 150ms cubic-bezier(0.175, 0.885, 0.32, 1.275),

--- a/src/components/CopyButton.js
+++ b/src/components/CopyButton.js
@@ -39,7 +39,7 @@ const StyledCopyToClipboard = styled(CopyToClipboard)`
 
   opacity: 0;
   transition: opacity 50ms ease-in-out;
-  z-index: 1;
+  z-index: 200;
   font-size: 12px;
   font-weight: 500;
   color: ${props => props.theme.text};


### PR DESCRIPTION
I noticed that the z-index of `BlockInsert` and `CopyButton` is rather low compared to the `Toolbar`. This makes it unusable in a Modal with a z-index > 1.