### PR TITLE
build stand-alone bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "yarn eslint src",
     "start": "webpack-serve --config example/webpack.config.js --content example/dist",
-    "build": "babel src/ -d lib/",
+    "build": "babel src/ -d lib/ && webpack -p",
     "prepublish": "yarn build"
   },
   "dependencies": {

--- a/src/bundle.js
+++ b/src/bundle.js
@@ -1,0 +1,4 @@
+// @flow
+import Editor from "./index";
+
+window.Editor = Editor;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,27 @@
+const path = require("path");
+
+module.exports = {
+  mode: "development",
+  entry: [
+    "regenerator-runtime/runtime",
+    path.resolve(__dirname, "src", "bundle.js"),
+  ],
+  output: {
+    filename: "rich-markdown-editor.js",
+    path: path.resolve(__dirname, "dist"),
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        use: {
+          loader: "babel-loader",
+        },
+      },
+    ],
+  },
+  resolve: {
+    mainFields: ["browser", "main"],
+  },
+};


### PR DESCRIPTION
Since we’re not using webpack, we need a stand-alone bundle that we can import via a `<script>` tag. Would be nice to have this bundle published on NPM.