### PR TITLE
Prevent nesting multiple links in `wrapLink` if a link is already selected

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -3,7 +3,9 @@ import { Editor, Block, KeyUtils } from "slate";
 
 const commands = {
   wrapLink(editor: Editor, href: string) {
-    editor.wrapInline({ type: "link", data: { href } });
+    if (!editor.isLinkActive()) {
+      editor.wrapInline({ type: "link", data: { href } });
+    }
   },
 
   unwrapLink(editor: Editor) {


### PR DESCRIPTION
Fixes a bug where toggling a link on a link is active would cause a link node to be inserted within a link node, which results in a messy slate object structure and also produces invalid HTML.