### PR TITLE
fix: save function now tests url of href string, adds https protocol if it's not working or contains forward slash.

### DIFF
--- a/src/components/Toolbar/LinkToolbar.js
+++ b/src/components/Toolbar/LinkToolbar.js
@@ -181,12 +181,19 @@ class LinkToolbar extends React.Component<Props, State> {
   save = (href: string) => {
     const { editor, link } = this.props;
     href = href.trim();
-
+    
     if (href) {
-      // If the input doesn't start with protocol or relative slash, make sure
-      // a protocol is added
-      if (!href.startsWith("/") && !href.match(/^https?:\/\//i)) {
-        href = `https://${href}`;
+      //If href passes the url test, 
+      //make sure href equals the new URL's href value.
+      //If it fails and if the input doesn't start with https protocol or relative slash, 
+      //make sure a default https protocol is added.
+      try {
+        let url_test = new URL(href);
+        href = url_test.href;
+      } catch (e){
+        if (!href.startsWith(("/")) && !href.match(/^https?:\/\//i)) {
+          href = `https://${href}`;
+        }
       }
       editor.setNodeByKey(link.key, { type: "link", data: { href } });
     } else if (link) {

--- a/src/components/Toolbar/LinkToolbar.js
+++ b/src/components/Toolbar/LinkToolbar.js
@@ -181,14 +181,14 @@ class LinkToolbar extends React.Component<Props, State> {
   save = (href: string) => {
     const { editor, link } = this.props;
     href = href.trim();
-    
+
     if (href) {
       //If href passes the url test, make sure href equals the new URL's href value.
       //If it fails and doesn't start with https protocol or relative slash, make sure a default https protocol is added.
       try {
         let url_test = new URL(href);
         href = url_test.href;
-      } catch (e){
+      } catch (e) {
         if (!href.startsWith("/") && !href.match(/^https?:\/\//i)) {
           href = `https://${href}`;
         }

--- a/src/components/Toolbar/LinkToolbar.js
+++ b/src/components/Toolbar/LinkToolbar.js
@@ -183,15 +183,13 @@ class LinkToolbar extends React.Component<Props, State> {
     href = href.trim();
     
     if (href) {
-      //If href passes the url test, 
-      //make sure href equals the new URL's href value.
-      //If it fails and if the input doesn't start with https protocol or relative slash, 
-      //make sure a default https protocol is added.
+      //If href passes the url test, make sure href equals the new URL's href value.
+      //If it fails and doesn't start with https protocol or relative slash, make sure a default https protocol is added.
       try {
         let url_test = new URL(href);
         href = url_test.href;
       } catch (e){
-        if (!href.startsWith(("/")) && !href.match(/^https?:\/\//i)) {
+        if (!href.startsWith("/") && !href.match(/^https?:\/\//i)) {
           href = `https://${href}`;
         }
       }


### PR DESCRIPTION
Added creation of URL from href string in save function, to test if it has a protocol and if it is a working link. If it is a working link, href then equals the url test href. If it fails, an automatic https protocol is added if it doesn't start with one already or doesn't start with a forward slash:

`try { let url_test = new URL(href); href = url_test.href; } catch (e){ if (!href.startsWith("/") && !href.match(/^https?:\/\//i)) { href =https://${href}; } }
`

Further development ideas for the save function: alert users if protocol is unknown even if URL creation passes. Alert users if their created link is missing a protocol, give them options from a list of common protocols, to add one.

Note: this pull request was previously closed in an attempt to reopen a [previous issue](https://github.com/outline/rich-markdown-editor/pull/132), in which this pull request tried to resolve..