### PR TITLE
feat: Allow overriding individual theme properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ Allows overriding the serializer, defaults to `slate-md-serializer` when not set
 
 Allows overriding the inbuilt theme to brand the editor, for example use your own font face and brand colors to have the editor fit within your application. See the [inbuilt theme](/src/theme.js) for an example of the keys that should be provided.
 
+#### `themeOverrides`
+
+Allows overriding individual properties from the inbuilt theme to brand the editor, for example, `themeOverrides={{ zIndex: 200 }}` will retain the built in theme with a z-index of 200. See the [inbuilt theme](/src/theme.js) for an example of the keys that can be overriden.
+
 #### `dark`
 
 With `dark` set to `true` the editor will use a default dark theme that's included. See the [source here](/src/theme.js).

--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,7 @@ export type Props = {
   schema?: Schema,
   serializer?: Serializer,
   theme?: Object,
+  themeOverrides?: Object,
   uploadImage?: (file: File) => Promise<string>,
   onSave?: ({ done?: boolean }) => void,
   onCancel?: () => void,
@@ -264,10 +265,14 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
       defaultValue,
       autoFocus,
       plugins,
+      themeOverrides,
       ...rest
     } = this.props;
 
-    const theme = this.props.theme || (dark ? darkTheme : lightTheme);
+    const baseTheme = this.props.theme || (dark ? darkTheme : lightTheme);
+    const theme = themeOverrides
+      ? { ...baseTheme, ...themeOverrides }
+      : baseTheme;
 
     return (
       <Flex


### PR DESCRIPTION
Add `themeOverrides` prop to enable overriding specific properties of the theme rather than having to define an entire theme.