### PR TITLE
fix: Issue #120: Added auto write button to programmatically change the editor value.

### DIFF
--- a/example/src/index.js
+++ b/example/src/index.js
@@ -3,6 +3,7 @@ import * as React from "react";
 import { debounce } from "lodash";
 import ReactDOM from "react-dom";
 import Editor from "../../src";
+import Serializer from "../../src/serializer";
 
 const element = document.getElementById("main");
 const savedText = localStorage.getItem("saved");
@@ -11,6 +12,8 @@ const exampleText = `
 
 This is example content. It is persisted between reloads in localStorage.
 `;
+const autoWriteTemplate = `Document has been restarted with a template!`;
+
 const defaultValue = savedText || exampleText;
 
 class GoogleEmbed extends React.Component<*> {
@@ -23,12 +26,20 @@ class GoogleEmbed extends React.Component<*> {
 class Example extends React.Component<*, { readOnly: boolean, dark: boolean }> {
   state = {
     readOnly: false,
+    autoWrite: false,
     dark: localStorage.getItem("dark") === "enabled",
   };
+
 
   handleToggleReadOnly = () => {
     this.setState({ readOnly: !this.state.readOnly });
   };
+
+  handleToggleAutoWrite = () => {
+    if (!this.state.readOnly) {
+      this.setState({ autoWrite: !this.state.autoWrite });
+    }
+  }
 
   handleToggleDark = () => {
     const dark = !this.state.dark;
@@ -44,54 +55,114 @@ class Example extends React.Component<*, { readOnly: boolean, dark: boolean }> {
     const { body } = document;
     if (body) body.style.backgroundColor = this.state.dark ? "#181A1B" : "#FFF";
 
-    return (
-      <div style={{ marginTop: "60px" }}>
-        <p>
-          <button type="button" onClick={this.handleToggleReadOnly}>
-            {this.state.readOnly ? "Editable" : "Read Only"}
-          </button>
-          <button type="button" onClick={this.handleToggleDark}>
-            {this.state.dark ? "Light Theme" : "Dark Theme"}
-          </button>
-        </p>
-        <Editor
-          id="example"
-          readOnly={this.state.readOnly}
-          defaultValue={defaultValue}
-          onSave={options => console.log("Save triggered", options)}
-          onCancel={() => console.log("Cancel triggered")}
-          onChange={this.handleChange}
-          onClickLink={href => console.log("Clicked link: ", href)}
-          onClickHashtag={tag => console.log("Clicked hashtag: ", tag)}
-          onShowToast={message => window.alert(message)}
-          onSearchLink={async term => {
-            console.log("Searched link: ", term);
-            return [
-              {
-                title: term,
-                url: "localhost",
-              },
-            ];
-          }}
-          uploadImage={file => {
-            console.log("File upload triggered: ", file);
+    if (!this.state.autoWrite) {
+      console.log("NOT Auto Write");
+      return (
+        <div key={1} style={{ marginTop: "60px" }}>
+          <p>
+            <button type="button" onClick={this.handleToggleReadOnly}>
+              {this.state.readOnly ? "Editable" : "Read Only"}
+            </button>
+            <button type="button" onClick={this.handleToggleAutoWrite}>
+              Auto Write
+            </button>
+            <button type="button" onClick={this.handleToggleDark}>
+              {this.state.dark ? "Light Theme" : "Dark Theme"}
+            </button>
+          </p>
+          <Editor
+            id="example"
+            readOnly={this.state.readOnly}
+            autoWrite={this.state.autoWrite}
+            defaultValue={defaultValue}
+            onSave={options => console.log("Save triggered", options)}
+            onCancel={() => console.log("Cancel triggered")}
+            onChange={this.handleChange}
+            onClickLink={href => console.log("Clicked link: ", href)}
+            onClickHashtag={tag => console.log("Clicked hashtag: ", tag)}
+            onShowToast={message => window.alert(message)}
+            onSearchLink={async term => {
+              console.log("Searched link: ", term);
+              return [
+                {
+                  title: term,
+                  url: "localhost",
+                },
+              ];
+            }}
+            uploadImage={file => {
+              console.log("File upload triggered: ", file);
 
-            // Delay to simulate time taken to upload
-            return new Promise(resolve => {
-              setTimeout(() => resolve("http://lorempixel.com/400/200/"), 1500);
-            });
-          }}
-          getLinkComponent={node => {
-            if (node.data.get("href").match(/google/)) {
-              return GoogleEmbed;
-            }
-          }}
-          dark={this.state.dark}
-          autoFocus
-          toc
-        />
-      </div>
-    );
+              // Delay to simulate time taken to upload
+              return new Promise(resolve => {
+                setTimeout(() => resolve("http://lorempixel.com/400/200/"), 1500);
+              });
+            }}
+            getLinkComponent={node => {
+              if (node.data.get("href").match(/google/)) {
+                return GoogleEmbed;
+              }
+            }}
+            dark={this.state.dark}
+            autoFocus
+            toc
+          />
+        </div>
+      );
+    } else {
+      return (
+        <div key={2} style={{ marginTop: "60px" }}>
+          <p>
+            <button type="button" onClick={this.handleToggleReadOnly}>
+              {this.state.readOnly ? "Editable" : "Read Only"}
+            </button>
+            <button type="button" onClick={this.handleToggleAutoWrite}>
+              Auto Write
+            </button>
+            <button type="button" onClick={this.handleToggleDark}>
+              {this.state.dark ? "Light Theme" : "Dark Theme"}
+            </button>
+          </p>
+          <Editor
+            id="example"
+            readOnly={this.state.readOnly}
+            autoWrite={this.state.autoWrite}
+            value={Serializer.deserialize(autoWriteTemplate)}
+            onSave={options => console.log("Save triggered", options)}
+            onCancel={() => console.log("Cancel triggered")}
+            onChange={this.handleChange}
+            onClickLink={href => console.log("Clicked link: ", href)}
+            onClickHashtag={tag => console.log("Clicked hashtag: ", tag)}
+            onShowToast={message => window.alert(message)}
+            onSearchLink={async term => {
+              console.log("Searched link: ", term);
+              return [
+                {
+                  title: term,
+                  url: "localhost",
+                },
+              ];
+            }}
+            uploadImage={file => {
+              console.log("File upload triggered: ", file);
+
+              // Delay to simulate time taken to upload
+              return new Promise(resolve => {
+                setTimeout(() => resolve("http://lorempixel.com/400/200/"), 1500);
+              });
+            }}
+            getLinkComponent={node => {
+              if (node.data.get("href").match(/google/)) {
+                return GoogleEmbed;
+              }
+            }}
+            dark={this.state.dark}
+            autoFocus
+            toc
+          />
+        </div>
+      );
+    }
   }
 }
 

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -15,6 +15,7 @@ const autoWriteTemplate = `Document has been restarted with a template!`;
 
 class GoogleEmbed extends React.Component<*> {
   render() {
+    console.log("google embeded render");
     const { attributes, node } = this.props;
     return <p {...attributes}>Google Embed ({node.data.get("href")})</p>;
   }
@@ -35,7 +36,12 @@ class Example extends React.Component<*, { readOnly: boolean, dark: boolean }> {
 
   handleToggleAutoWrite = () => {
     if (!this.state.readOnly) {
-      this.setState({ autoWrite: !this.state.autoWrite });
+      //saves the the value before switching editors in render.
+      localStorage.setItem("saved", autoWriteTemplate);
+      this.setState({ 
+        autoWrite: !this.state.autoWrite,
+        defaultValue: localStorage.getItem("saved") || exampleText
+      });
     }
   }
 
@@ -46,13 +52,19 @@ class Example extends React.Component<*, { readOnly: boolean, dark: boolean }> {
   };
 
   handleChange = debounce(value => {
+    /*if(this.state.autoWrite){
+      return this.setState({ 
+        autoWrite: !this.state.autoWrite,
+        defaultValue: localStorage.getItem("saved") || exampleText
+      });
+    }*/
+
     localStorage.setItem("saved", value());
   }, 250);
  
   render() {
     const { body } = document;
     if (body) body.style.backgroundColor = this.state.dark ? "#181A1B" : "#FFF";
-
     if (!this.state.autoWrite) {
       return (
         <div style={{ marginTop: "60px" }}>
@@ -126,7 +138,6 @@ class Example extends React.Component<*, { readOnly: boolean, dark: boolean }> {
             id="example"
             readOnly={this.state.readOnly}
             autoWrite={this.state.autoWrite}
-            defaultValue={this.state.defaultValue}
             value={Serializer.deserialize(autoWriteTemplate)}
             onSave={options => console.log("Save triggered", options)}
             onCancel={() => console.log("Cancel triggered")}

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -6,15 +6,12 @@ import Editor from "../../src";
 import Serializer from "../../src/serializer";
 
 const element = document.getElementById("main");
-const savedText = localStorage.getItem("saved");
 const exampleText = `
 # Welcome
 
 This is example content. It is persisted between reloads in localStorage.
 `;
 const autoWriteTemplate = `Document has been restarted with a template!`;
-
-const defaultValue = savedText || exampleText;
 
 class GoogleEmbed extends React.Component<*> {
   render() {
@@ -24,12 +21,13 @@ class GoogleEmbed extends React.Component<*> {
 }
 
 class Example extends React.Component<*, { readOnly: boolean, dark: boolean }> {
+  
   state = {
     readOnly: false,
     autoWrite: false,
     dark: localStorage.getItem("dark") === "enabled",
+    defaultValue: localStorage.getItem("saved") || exampleText
   };
-
 
   handleToggleReadOnly = () => {
     this.setState({ readOnly: !this.state.readOnly });
@@ -50,31 +48,31 @@ class Example extends React.Component<*, { readOnly: boolean, dark: boolean }> {
   handleChange = debounce(value => {
     localStorage.setItem("saved", value());
   }, 250);
-
+ 
   render() {
     const { body } = document;
     if (body) body.style.backgroundColor = this.state.dark ? "#181A1B" : "#FFF";
 
     if (!this.state.autoWrite) {
-      console.log("NOT Auto Write");
       return (
-        <div key={1} style={{ marginTop: "60px" }}>
+        <div style={{ marginTop: "60px" }}>
           <p>
             <button type="button" onClick={this.handleToggleReadOnly}>
               {this.state.readOnly ? "Editable" : "Read Only"}
             </button>
             <button type="button" onClick={this.handleToggleAutoWrite}>
-              Auto Write
+              {this.state.autoWrite ? "Manual Write" : "Auto Write"}
             </button>
             <button type="button" onClick={this.handleToggleDark}>
               {this.state.dark ? "Light Theme" : "Dark Theme"}
             </button>
           </p>
           <Editor
+            key={1}
             id="example"
             readOnly={this.state.readOnly}
             autoWrite={this.state.autoWrite}
-            defaultValue={defaultValue}
+            defaultValue={this.state.defaultValue}
             onSave={options => console.log("Save triggered", options)}
             onCancel={() => console.log("Cancel triggered")}
             onChange={this.handleChange}
@@ -111,22 +109,24 @@ class Example extends React.Component<*, { readOnly: boolean, dark: boolean }> {
       );
     } else {
       return (
-        <div key={2} style={{ marginTop: "60px" }}>
+        <div style={{ marginTop: "60px" }}>
           <p>
             <button type="button" onClick={this.handleToggleReadOnly}>
               {this.state.readOnly ? "Editable" : "Read Only"}
             </button>
             <button type="button" onClick={this.handleToggleAutoWrite}>
-              Auto Write
+              {this.state.autoWrite ? "Manual Write" : "Auto Write"}
             </button>
             <button type="button" onClick={this.handleToggleDark}>
               {this.state.dark ? "Light Theme" : "Dark Theme"}
             </button>
           </p>
           <Editor
+            key={2}
             id="example"
             readOnly={this.state.readOnly}
             autoWrite={this.state.autoWrite}
+            defaultValue={this.state.defaultValue}
             value={Serializer.deserialize(autoWriteTemplate)}
             onSave={options => console.log("Save triggered", options)}
             onCancel={() => console.log("Cancel triggered")}

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 // @flow
 import * as React from "react";
 import { Value, Editor as TEditor, Schema, Node } from "slate";
-import { debounce } from "lodash";
 import { Editor } from "slate-react";
 import styled, { ThemeProvider } from "styled-components";
 import type { Plugin, SearchResult, Serializer } from "./types";
@@ -68,7 +67,6 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
   serializer: Serializer;
   prevSchema: ?Schema = null;
   schema: ?Schema = null;
-  defaultValue: String;
 
   constructor(props: Props) {
     super(props);
@@ -77,6 +75,7 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
       placeholder: props.placeholder,
       getLinkComponent: props.getLinkComponent,
     });
+
     // in Slate plugins earlier in the stack can opt not to continue
     // to later ones. By adding overrides first we give more control
     this.plugins = [...props.plugins, ...builtInPlugins];
@@ -84,27 +83,25 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
     this.serializer = props.serializer || Markdown;
 
     this.state = {
-      editorValue: this.serializer.deserialize(props.defaultValue)
+      editorValue: this.serializer.deserialize(props.defaultValue),
     };
-
   }
 
   componentDidMount() {
-    if (this.props.value != undefined) {
-      //setting up default value
-      this.defaultValue = this.serializer.serialize(this.props.value);
-      localStorage.setItem("saved", this.defaultValue);
-      return this.setState({ editorValue: this.serializer.deserialize(this.defaultValue) });
-    }
-
     this.scrollToAnchor();
+    if(this.props.value != undefined){
+      this.defaultValue = this.serializer.serialize(this.props.value);
+      return this.render();
+    }
     if (this.props.readOnly) return;
     if (typeof window !== "undefined") {
       window.addEventListener("keydown", this.handleKeyDown);
     }
+
     if (this.props.autoFocus) {
       this.focusAtEnd();
     }
+
   }
 
   componentDidUpdate(prevProps: Props) {
@@ -273,50 +270,93 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
       ...rest
     } = this.props;
 
-    const defaultValue = (this.props.value != undefined) ? this.defaultValue : this.props.defaultValue;
-    
     const theme = this.props.theme || (dark ? darkTheme : lightTheme);
+    const defaultValue = this.defaultValue || this.props.defaultValue;
 
-    return (
-      <Flex
-        style={style}
-        className={className}
-        onDrop={this.handleDrop}
-        onDragOver={this.cancelEvent}
-        onDragEnter={this.cancelEvent}
-        align="flex-start"
-        justify="center"
-        column
-        auto
-      >
-        <ThemeProvider theme={theme}>
-          <StyledEditor
-            ref={this.setEditorRef}
-            plugins={this.plugins}
-            value={this.state.editorValue}
-            defaultValue={defaultValue}
-            commands={commands}
-            queries={queries}
-            placeholder={placeholder}
-            schema={this.getSchema()}
-            onKeyDown={this.handleKeyDown}
-            onChange={this.handleChange}
-            onSave={onSave}
-            onSearchLink={onSearchLink}
-            onClickLink={onClickLink}
-            onImageUploadStart={onImageUploadStart}
-            onImageUploadStop={onImageUploadStop}
-            onShowToast={onShowToast}
-            readOnly={readOnly}
-            spellCheck={!readOnly}
-            uploadImage={uploadImage}
-            pretitle={pretitle}
-            options={defaultOptions}
-            {...rest}
-          />
-        </ThemeProvider>
-      </Flex>
-    );
+    if(this.props.value != undefined) {
+      return (
+        <Flex
+          style={style}
+          className={className}
+          onDrop={this.handleDrop}
+          onDragOver={this.cancelEvent}
+          onDragEnter={this.cancelEvent}
+          align="flex-start"
+          justify="center"
+          column
+          auto
+        >
+          <ThemeProvider theme={theme}>
+            <StyledEditor
+              key={3}
+              ref={this.setEditorRef}
+              plugins={this.plugins}
+              value={this.state.editorValue}
+              commands={commands}
+              queries={queries}
+              placeholder={placeholder}
+              schema={this.getSchema()}
+              onKeyDown={this.handleKeyDown}
+              onChange={this.handleChange}
+              onSave={onSave}
+              onSearchLink={onSearchLink}
+              onClickLink={onClickLink}
+              onImageUploadStart={onImageUploadStart}
+              onImageUploadStop={onImageUploadStop}
+              onShowToast={onShowToast}
+              readOnly={readOnly}
+              spellCheck={!readOnly}
+              uploadImage={uploadImage}
+              pretitle={pretitle}
+              options={defaultOptions}
+              {...rest}
+            />
+          </ThemeProvider>
+        </Flex>
+      );
+
+    } else {
+      return (
+        <Flex
+          style={style}
+          className={className}
+          onDrop={this.handleDrop}
+          onDragOver={this.cancelEvent}
+          onDragEnter={this.cancelEvent}
+          align="flex-start"
+          justify="center"
+          column
+          auto
+        >
+          <ThemeProvider theme={theme}>
+            <StyledEditor
+              key={4}
+              ref={this.setEditorRef}
+              plugins={this.plugins}
+              value={this.state.editorValue}
+              commands={commands}
+              queries={queries}
+              placeholder={placeholder}
+              schema={this.getSchema()}
+              onKeyDown={this.handleKeyDown}
+              onChange={this.handleChange}
+              onSave={onSave}
+              onSearchLink={onSearchLink}
+              onClickLink={onClickLink}
+              onImageUploadStart={onImageUploadStart}
+              onImageUploadStop={onImageUploadStop}
+              onShowToast={onShowToast}
+              readOnly={readOnly}
+              spellCheck={!readOnly}
+              uploadImage={uploadImage}
+              pretitle={pretitle}
+              options={defaultOptions}
+              {...rest}
+            />
+          </ThemeProvider>
+        </Flex>
+      );
+    }
   };
 }
 
@@ -328,7 +368,6 @@ const StyledEditor = styled(Editor)`
   font-size: 1em;
   line-height: 1.7em;
   width: 100%;
-
   h1,
   h2,
   h3,
@@ -337,58 +376,47 @@ const StyledEditor = styled(Editor)`
   h6 {
     font-weight: 500;
   }
-
   ul,
   ol {
     margin: 0 0.1em;
     padding-left: 1em;
-
     ul,
     ol {
       margin: 0.1em;
     }
   }
-
   p {
     position: relative;
     margin: 0;
   }
-
   a {
     color: ${props => props.theme.link};
   }
-
   a:hover {
     text-decoration: ${props => (props.readOnly ? "underline" : "none")};
   }
-
   li p {
     display: inline;
     margin: 0;
   }
-
   .todoList {
     list-style: none;
     padding-left: 0;
-
     .todoList {
       padding-left: 1em;
     }
   }
-
   .todo {
     span:last-child:focus {
       outline: none;
     }
   }
-
   blockquote {
     border-left: 3px solid ${props => props.theme.quote};
     margin: 0;
     padding-left: 10px;
     font-style: italic;
   }
-
   b,
   strong {
     font-weight: 600;

--- a/src/index.js
+++ b/src/index.js
@@ -89,9 +89,8 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
 
   componentDidMount() {
     this.scrollToAnchor();
-    if(this.props.value != undefined){
+    if (this.props.value !== undefined) {
       this.defaultValue = this.serializer.serialize(this.props.value);
-      return this.render();
     }
     if (this.props.readOnly) return;
     if (typeof window !== "undefined") {
@@ -101,7 +100,6 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
     if (this.props.autoFocus) {
       this.focusAtEnd();
     }
-
   }
 
   componentDidUpdate(prevProps: Props) {
@@ -273,9 +271,10 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
     const theme = this.props.theme || (dark ? darkTheme : lightTheme);
     const defaultValue = this.defaultValue || this.props.defaultValue;
 
-    if(this.props.value != undefined) {
+    if (this.props.value !== undefined) {
       return (
         <Flex
+          key={3}
           style={style}
           className={className}
           onDrop={this.handleDrop}
@@ -288,9 +287,9 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
         >
           <ThemeProvider theme={theme}>
             <StyledEditor
-              key={3}
               ref={this.setEditorRef}
               plugins={this.plugins}
+              defaultValue={defaultValue}
               value={this.state.editorValue}
               commands={commands}
               queries={queries}
@@ -314,10 +313,10 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
           </ThemeProvider>
         </Flex>
       );
-
     } else {
       return (
         <Flex
+          key={4}
           style={style}
           className={className}
           onDrop={this.handleDrop}
@@ -330,9 +329,9 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
         >
           <ThemeProvider theme={theme}>
             <StyledEditor
-              key={4}
               ref={this.setEditorRef}
               plugins={this.plugins}
+              defaultValue={defaultValue}
               value={this.state.editorValue}
               commands={commands}
               queries={queries}

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,7 @@ export type Props = {
   plugins: Plugin[],
   autoFocus?: boolean,
   readOnly?: boolean,
+  autoWrite?: boolean,
   headingsOffset?: number,
   toc?: boolean,
   dark?: boolean,
@@ -83,7 +84,7 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
     this.serializer = props.serializer || Markdown;
 
     this.state = {
-      editorValue: this.serializer.deserialize(props.defaultValue),
+      editorValue: this.serializer.deserialize(props.defaultValue)
     };
   }
 
@@ -91,6 +92,7 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
     this.scrollToAnchor();
 
     if (this.props.readOnly) return;
+
     if (typeof window !== "undefined") {
       window.addEventListener("keydown", this.handleKeyDown);
     }
@@ -206,6 +208,7 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
     next: Function = () => {}
   ) => {
     if (this.props.readOnly) return next();
+    if (this.props.autoWrite) return next();
 
     switch (ev.key) {
       case "s":
@@ -247,6 +250,7 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
   render = () => {
     const {
       readOnly,
+      autoWrite,
       pretitle,
       placeholder,
       onSave,
@@ -299,6 +303,7 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
             onImageUploadStop={onImageUploadStop}
             onShowToast={onShowToast}
             readOnly={readOnly}
+            autoWrite={autoWrite}
             spellCheck={!readOnly}
             uploadImage={uploadImage}
             pretitle={pretitle}


### PR DESCRIPTION
This is in no way finished but I wanted to show my progress as I will be busy the next 2 or 3 days.

To attempt to programmatically change the editor value (from [issue 120](https://github.com/outline/rich-markdown-editor/issues/120)),
I created an Auto Write button / function to re render a different Editor taking in a new deserialised string into it's value:

`
      <Editor
            id="example"
            readOnly={this.state.readOnly}
            autoWrite={this.state.autoWrite}
            value={Serializer.deserialize(autoWriteTemplate)} // autoWriteTemplate is a long string.
      />
`
but only when autoWrite is set to true.

So far it works, but I haven't set it to remount back to the original editor yet. When passing in a value into the editor it dissables the user input functionality, so it needs to set back to its original editor afterwards to allow edits.

This should be possible by resetting autoWrite to false so it re renders back, but it brings it back to its origin value, without saving the new editorValue to the autoWriteTemplate string. This is confirmed by constantly toggling auto write button (eventually I plan to have it reset back to false automatically, per click). 

I can only seem to save this value by refreshing the page when the auto write template is set. After refreshing, if I keep toggling autowrite, it shows that the template has been saved

Is there anything that needs to be called after passing the deserialised string into the value key, to make sure it is properly saved? I am still trying to understand the repository more, but so far I am learning a lot. :)

@tommoor If I am going off track with the required task here, please let me know. :) I initially set out to try and fix it from the example app first, but I've made some changes to the src/index. No rush in merging this. I am just looking for some feedback, or any suggestions here.

Further developments to do:
clean up the render function, and keep conditional if statements to a separate function to mount the correct editor (changes to the editor component are only minimum with just the addition of the value key.)

