### PR TITLE
fix: Issue #131: Preventing changing of schema and previous schema values when props schema is undefined.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -234,7 +234,7 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
   };
 
   getSchema = () => {
-    if (this.prevSchema !== this.props.schema) {
+    if (this.props.schema != undefined && this.props.schema !== this.prevSchema) {
       this.schema = {
         ...defaultSchema,
         ...(this.props.schema || {}),

--- a/src/index.js
+++ b/src/index.js
@@ -234,12 +234,17 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
   };
 
   getSchema = () => {
-    if (this.props.schema != undefined && this.props.schema !== this.prevSchema) {
+    if (
+      this.props.schema !== undefined &&
+      this.props.schema !== this.prevSchema
+    ) {
       this.schema = {
         ...defaultSchema,
         ...(this.props.schema || {}),
       };
+      console.log(this.props.schema);
       this.prevSchema = this.props.schema;
+      console.log(this.prevSchema);
     }
     return this.schema;
   };

--- a/src/index.js
+++ b/src/index.js
@@ -242,9 +242,7 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
         ...defaultSchema,
         ...(this.props.schema || {}),
       };
-      console.log(this.props.schema);
       this.prevSchema = this.props.schema;
-      console.log(this.prevSchema);
     }
     return this.schema;
   };


### PR DESCRIPTION
This pr request now prevents changing of schema and previous schema values when.. 

- props schema is undefined

Here is the Get Schema function now:

` 
getSchema = () => {
    if (this.props.schema !== undefined && this.props.schema !== this.prevSchema) {
      this.schema = {
        ...defaultSchema,
        ...(this.props.schema || {}),
      };
      this.prevSchema = this.props.schema;
    }
    return this.schema;
  };
`

Issue #131 highlighted that props schema equaling undefined can potentially break the application.

Any other suggestions to prevent other bugs from this function please mention here. I will keep updating the function and this PR in relation to suggested changes. If you think this change is going to cause other issues please also mention it.