### PR TITLE
docs: fixes onSearchLink code example position

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,13 +130,6 @@ Triggered once an image upload has succeeded or failed.
 
 The editor provides an ability to search for links to insert from the formatting toolbar. If this callback is provided it should accept a search term as the only parameter and return a promise that resolves to an array of [SearchResult](/src/types.js) objects. eg:
 
-#### `onShowToast(message: string)`
-
-Triggered when the editor wishes to show a toast message to the user. Hook into your apps
-notification system, or simplisticly use `window.alert(message)`.
-
-
-
 ```javascript
 <Editor
   onSearchLink={async searchTerm => {
@@ -149,6 +142,12 @@ notification system, or simplisticly use `window.alert(message)`.
   }}
 />
 ```
+
+#### `onShowToast(message: string)`
+
+Triggered when the editor wishes to show a toast message to the user. Hook into your apps
+notification system, or simplisticly use `window.alert(message)`.
+
 
 #### `onClickLink(href: string)`
 


### PR DESCRIPTION
The `onSearchLink` code snippet was under the `onShowToast` description.

The git diff is showing this as moving the `onShowToast` description down, which is effectively the same thing. 