### PR TITLE
fix: Removes deprecated componentWillReceiveProps

### DIFF
--- a/src/components/Table/Toolbar.js
+++ b/src/components/Table/Toolbar.js
@@ -39,30 +39,30 @@ class Toolbar extends React.Component<Props, State> {
     left: 0,
   };
 
-  componentWillReceiveProps() {
-    if (!this.props.cell) return;
+  static getDerivedStateFromProps(nextProps, prevState) {
+    if (!nextProps.cell) return;
 
-    const element = findDOMNode(this.props.cell);
+    const element = findDOMNode(nextProps.cell);
     if (!(element instanceof HTMLElement)) return;
 
     const rect = element.getBoundingClientRect();
-    const menuWidth = MENU_WIDTHS[this.props.type];
+    const menuWidth = MENU_WIDTHS[nextProps.type];
     const menuHeight = 40;
 
     // Position the menu correctly depending on the type, cell and scroll position
     const left =
-      MENU_ALIGN[this.props.type] === "center"
+      MENU_ALIGN[nextProps.type] === "center"
         ? Math.round(
-            rect.left + window.scrollX + rect.width / 2 - menuWidth / 2
+            rect.left + window.scrollX + rect.width / 2 - menuWidth / 2,
           )
         : Math.round(rect.left + window.scrollX - menuWidth / 2);
     const top = Math.round(rect.top + window.scrollY - menuHeight - 12);
 
-    this.setState(state => {
-      if (state.left !== left || state.top !== top) {
-        return { left, top };
-      }
-    });
+    if (prevState.left !== left || prevState.top !== top) {
+      return { left, top };
+    }
+
+    return null;
   }
 
   render() {

--- a/src/components/Toolbar/index.js
+++ b/src/components/Toolbar/index.js
@@ -47,9 +47,19 @@ export default class Toolbar extends React.Component<Props, State> {
     }
   };
 
-  componentWillReceiveProps = debounce(() => {
-    this.update();
-  }, 100);
+  componentDidUpdate = prevProps => {
+    this.updateIfPropsChanged(prevProps);
+  };
+
+  updateIfPropsChanged = debounce(
+    prevProps => {
+      if (!isEqual(this.props, prevProps)) {
+        this.update();
+      }
+    },
+    100,
+    { leading: true, trailing: true },
+  );
 
   hideLinkToolbar = () => {
     this.setState({ link: undefined });
@@ -138,7 +148,7 @@ export default class Toolbar extends React.Component<Props, State> {
     const left =
       rect.left + window.scrollX - this.menu.offsetWidth / 2 + rect.width / 2;
     newState.top = `${Math.round(
-      rect.top + window.scrollY - this.menu.offsetHeight
+      rect.top + window.scrollY - this.menu.offsetHeight,
     )}px`;
     newState.left = `${Math.round(Math.max(padding, left))}px`;
 


### PR DESCRIPTION
`componentWillReceiveProps` is now deprecated and throws an error. 

https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops

Started by fixing it in the main toolbar component. 

I don't use tables in my setup so did not test but let me know if you notice anything funny about the toolbar. 
