### PR TITLE
fix: Dodgy checklist behavior in Firefox and Safari

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -684,13 +684,13 @@ const StyledEditor = styled("div")<{ readOnly: boolean }>`
     list-style: none;
     padding-left: 0;
     margin-left: -4px;
-
-    ul.checkbox_list {
-      padding-left: 20px;
-    }
   }
 
-  ul.checkbox_list li.checked > span > p {
+  ul.checkbox_list li {
+    display: flex;
+  }
+
+  ul.checkbox_list li.checked > div > p {
     color: ${props => props.theme.textSecondary};
     text-decoration: line-through;
   }

--- a/src/nodes/CheckboxItem.ts
+++ b/src/nodes/CheckboxItem.ts
@@ -41,15 +41,20 @@ export default class CheckboxItem extends Node {
           class: node.attrs.checked ? "checked" : undefined,
         },
         [
-          "input",
+          "span",
           {
-            id: node.attrs.id,
-            type: "checkbox",
             contentEditable: false,
-            checked: node.attrs.checked ? true : undefined,
           },
+          [
+            "input",
+            {
+              id: node.attrs.id,
+              type: "checkbox",
+              checked: node.attrs.checked ? true : undefined,
+            },
+          ],
         ],
-        ["span", 0],
+        ["div", 0],
       ],
     };
   }
@@ -66,6 +71,9 @@ export default class CheckboxItem extends Node {
               event.target instanceof HTMLInputElement &&
               event.target.type === "checkbox"
             ) {
+              event.preventDefault();
+              event.stopPropagation();
+
               const result = view.posAtCoords({
                 left: event.clientX,
                 top: event.clientY,


### PR DESCRIPTION
A good reminder to be checking across all three major rendering engines.

![image](https://user-images.githubusercontent.com/380914/81481588-2788be00-91e6-11ea-8098-7258b6569cf4.png)

This also fixes an issue where after all content in a todo list node is deleted it becomes hard to type new content that also affected Chrome.

closes #176 