### PR TITLE
fix: Allow heading slugs to contain non-latin characters

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-medium-image-zoom": "^3.0.16",
     "react-portal": "^4.2.1",
     "refractor": "^2.10.1",
-    "slugify": "^1.3.6",
+    "slugify": "^1.4.0",
     "smooth-scroll-into-view-if-needed": "^1.1.27",
     "styled-components": "^5.0.0",
     "typescript": "^3.7.5"

--- a/src/lib/headingToSlug.ts
+++ b/src/lib/headingToSlug.ts
@@ -3,9 +3,15 @@ import { escape } from "lodash";
 import slugify from "slugify";
 
 // Slugify, escape, and remove periods from headings so that they are
-// compatible with url hashes AND dom selectors
+// compatible with both url hashes AND dom ID's (querySelector does not like
+// ID's that begin with a number or a period, for example).
 function safeSlugify(text: string) {
-  return `h-${escape(slugify(text, { lower: true }).replace(".", "-"))}`;
+  return `h-${escape(
+    slugify(text, {
+      remove: /[!"#$%&'\.()*+,\/:;<=>?@\[\]\\^_`{|}~]/g,
+      lower: true,
+    })
+  )}`;
 }
 
 // calculates a unique slug for this heading based on it's text and position

--- a/src/nodes/Heading.ts
+++ b/src/nodes/Heading.ts
@@ -78,7 +78,11 @@ export default class Heading extends Node {
       // this is unfortunate but appears to be the best way to grab the anchor
       // as it's added directly to the dom by a decoration.
       const slug = `#${event.target.parentElement.parentElement.name}`;
-      copy(window.location.href + slug);
+
+      // the existing url might contain a hash already, lets make sure to remove
+      // that rather than appending another one.
+      const urlWithoutHash = window.location.href.split("#")[0];
+      copy(urlWithoutHash + slug);
 
       if (this.options.onShowToast) {
         this.options.onShowToast("Link copied to clipboard");

--- a/yarn.lock
+++ b/yarn.lock
@@ -5057,7 +5057,7 @@ slice-ansi@^2.1.0:
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
 
-slugify@^1.3.6:
+slugify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.4.0.tgz#c9557c653c54b0c7f7a8e786ef3431add676d2cb"
   integrity sha512-FtLNsMGBSRB/0JOE2A0fxlqjI6fJsgHGS13iTuVT28kViI4JjUiNqp/vyis0ZXYcMnpR3fzGNkv+6vRlI2GwdQ==


### PR DESCRIPTION
fix: Don't append a double hash when copying heading link