### PR TITLE
Fix typescript support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "rich-markdown-editor",
   "description": "A rich text editor with Markdown shortcuts",
-  "version": "10.0.0-15",
-  "main": "dist/index.js",
+  "version": "10.0.0-16",
+  "main": "dist/lib/index.js",
+  "typings": "dist/@types/index.d.ts",
   "license": "BSD-3-Clause",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
@@ -11,6 +12,7 @@
     "build": "tsc",
     "prepublish": "yarn build"
   },
+  
   "dependencies": {
     "copy-to-clipboard": "^3.0.8",
     "lodash": "^4.17.11",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,21 @@
 {
   "compilerOptions": {
-    "outDir": "./dist/",
     "sourceMap": true,
     "strict": false,
-    "removeComments": true,
     "noImplicitAny": false,
     "esModuleInterop": true,
     "allowJs": true,
     "module": "commonjs",
     "target": "es2017",
     "jsx": "react",
-    "types": ["react"]
+    "types": ["react"],
+    "rootDir": "src",
+    "outDir": "dist/lib",
+    "stripInternal": true,
+    "removeComments": true,
+    "declarationMap": true,
+    "declaration": true,
+    "declarationDir": "dist/@types",
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
Currently, you don't seem to export the type declarations. Without it, typescript can't find the module and its types. Unless there is a separate @types package that I might have missed.
