### PR TITLE
feat: Move from getLinkComponent to embeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ Optionally define embeds which will be inserted in place of links when the `matc
 <Editor
   embeds={[
     {
-      name: "doc",
       title: "Google Doc",
       keywords: "google docs gdocs",
       icon: <GoogleDocIcon />,

--- a/README.md
+++ b/README.md
@@ -70,6 +70,26 @@ A React component that will be wrapped around items that have an optional toolti
 
 A number that will offset the document headings by a number of levels. For example, if you already nest the editor under a main `h1` title you might want the user to only be able to create `h2` headings and below, in this case you would set the prop to `1`.
 
+#### `embeds`
+
+Optionally define embeds which will be inserted in place of links when the `matcher` function returns a truthy value. The matcher method's return value will be available on the component under `props.attrs.matches`. If `title` and `icon` are provided then the embed will also appear in the block menu.
+
+```javascript
+<Editor
+  embeds={[
+    {
+      name: "doc",
+      title: "Google Doc",
+      keywords: "google docs gdocs",
+      icon: <GoogleDocIcon />,
+      matcher: href => href.matches(/docs.google.com/i),
+      component: GoogleDocEmbed,
+      showInBlockMenu: true
+    }
+  ]}
+/>
+```
+
 ### Callbacks
 
 #### `uploadImage(file: Blob): Promise<string>`
@@ -161,20 +181,6 @@ import { history } from "react-router";
 <Editor
   onClickHashtag={tag => {
     history.push(`/hashtags/${tag}`);
-  }}
-/>
-```
-
-#### `getLinkComponent(url: string): void | ReactNode`
-
-This callback allows links to "request" an alternative component to display instead of an inline link. Given a url return `undefined` for no replacement or a valid React component to replace the standard link display. This is used to support embeds.
-
-```javascript
-<Editor
-  getLinkComponent={url => {
-    if (url.match(/https?:\/\/youtube\.com/)) {
-      return <MyFancyYoutubeEmbed url={url} />;
-    }
   }}
 />
 ```

--- a/README.md
+++ b/README.md
@@ -82,8 +82,7 @@ Optionally define embeds which will be inserted in place of links when the `matc
       keywords: "google docs gdocs",
       icon: <GoogleDocIcon />,
       matcher: href => href.matches(/docs.google.com/i),
-      component: GoogleDocEmbed,
-      showInBlockMenu: true
+      component: GoogleDocEmbed
     }
   ]}
 />

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -12,10 +12,17 @@ This is example content. It is persisted between reloads in localStorage.
 `;
 const defaultValue = savedText || exampleText;
 
-class GoogleEmbed extends React.Component {
+class YoutubeEmbed extends React.Component {
   render() {
     const { attrs } = this.props;
-    return <p>Google Embed ({attrs.href})</p>;
+    console.log(this.props);
+    const videoId = attrs.matches[1];
+
+    return (
+      <iframe
+        src={`https://www.youtube.com/embed/${videoId}?modestbranding=1`}
+      />
+    );
   }
 }
 
@@ -101,11 +108,25 @@ class Example extends React.Component {
               );
             });
           }}
-          getLinkComponent={href => {
-            if (href.match(/google/)) {
-              return GoogleEmbed;
-            }
-          }}
+          embeds={[
+            {
+              title: "YouTube",
+              name: "youtube",
+              icon: () => (
+                <img
+                  src="https://upload.wikimedia.org/wikipedia/commons/7/75/YouTube_social_white_squircle_%282017%29.svg"
+                  width={24}
+                  height={24}
+                />
+              ),
+              matcher: url => {
+                return url.match(
+                  /(?:https?:\/\/)?(?:www\.)?youtu\.?be(?:\.com)?\/?.*(?:watch|embed)?(?:.*v=|v\/|\/)([a-zA-Z0-9_-]{11})$/i
+                );
+              },
+              component: YoutubeEmbed,
+            },
+          ]}
           dark={this.state.dark}
           autoFocus
         />

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -111,7 +111,7 @@ class Example extends React.Component {
           embeds={[
             {
               title: "YouTube",
-              name: "youtube",
+              keywords: "youtube video tube google",
               icon: () => (
                 <img
                   src="https://upload.wikimedia.org/wikipedia/commons/7/75/YouTube_social_white_squircle_%282017%29.svg"

--- a/src/components/BlockMenu.tsx
+++ b/src/components/BlockMenu.tsx
@@ -4,7 +4,7 @@ import { Portal } from "react-portal";
 import { EditorView } from "prosemirror-view";
 import { findParentNode } from "prosemirror-utils";
 import styled from "styled-components";
-
+import { EmbedDescriptor } from "../types";
 import BlockMenuItem from "./BlockMenuItem";
 import VisuallyHidden from "./VisuallyHidden";
 import getDataTransferFiles from "../lib/getDataTransferFiles";
@@ -23,6 +23,7 @@ type Props = {
   onImageUploadStop: () => void;
   onShowToast: (message: string) => void;
   onClose: () => void;
+  embeds: EmbedDescriptor[];
 };
 
 class BlockMenu extends React.Component<Props> {
@@ -221,8 +222,23 @@ class BlockMenu extends React.Component<Props> {
   }
 
   get filtered() {
-    const { search = "" } = this.props;
-    const items = getMenuItems();
+    const { embeds, search = "" } = this.props;
+    let items = getMenuItems();
+    const embedItems = [];
+
+    for (const embed of embeds) {
+      if (embed.title && embed.icon) {
+        embedItems.push(embed);
+      }
+    }
+
+    if (embedItems.length) {
+      items.push({
+        name: "separator",
+      });
+      items = items.concat(embedItems);
+    }
+    console.log(items);
 
     const filtered = items.filter(item => {
       if (item.name === "separator") return true;

--- a/src/components/BlockMenu.tsx
+++ b/src/components/BlockMenu.tsx
@@ -426,6 +426,7 @@ const LinkInputWrapper = styled.div`
 const LinkInput = styled(Input)`
   height: 36px;
   width: 100%;
+  color: ${props => props.theme.blockToolbarText};
 `;
 
 const List = styled.ol`

--- a/src/components/BlockMenu.tsx
+++ b/src/components/BlockMenu.tsx
@@ -171,6 +171,9 @@ class BlockMenu extends React.Component<Props> {
     const matches = this.state.insertItem.matcher(href);
 
     if (matches) {
+      event.preventDefault();
+      event.stopPropagation();
+
       this.insertBlock({
         name: "embed",
         attrs: {

--- a/src/components/BlockMenu.tsx
+++ b/src/components/BlockMenu.tsx
@@ -6,6 +6,7 @@ import { findParentNode } from "prosemirror-utils";
 import styled from "styled-components";
 import { EmbedDescriptor } from "../types";
 import BlockMenuItem from "./BlockMenuItem";
+import Input from "./Input";
 import VisuallyHidden from "./VisuallyHidden";
 import getDataTransferFiles from "../lib/getDataTransferFiles";
 import insertFiles from "../commands/insertFiles";
@@ -125,6 +126,7 @@ class BlockMenu extends React.Component<Props> {
 
     if (event.key === "Escape") {
       this.props.onClose();
+      this.props.view.focus();
     }
   };
 
@@ -146,6 +148,29 @@ class BlockMenu extends React.Component<Props> {
         return;
       }
 
+      this.insertBlock({
+        name: "embed",
+        attrs: {
+          href,
+          component: this.state.insertItem.component,
+          matches,
+        },
+      });
+    }
+
+    if (event.key === "Escape") {
+      this.props.onClose();
+      this.props.view.focus();
+    }
+  };
+
+  handleLinkInputPaste = (event: React.ClipboardEvent<HTMLInputElement>) => {
+    if (!this.props.isActive) return;
+
+    const href = event.clipboardData.getData("text/plain");
+    const matches = this.state.insertItem.matcher(href);
+
+    if (matches) {
       this.insertBlock({
         name: "embed",
         attrs: {
@@ -324,12 +349,19 @@ class BlockMenu extends React.Component<Props> {
           {...positioning}
         >
           {insertItem ? (
-            <input
-              type="text"
-              placeholder="Paste link…"
-              onKeyDown={this.handleLinkInputKeydown}
-              autoFocus
-            />
+            <LinkInputWrapper>
+              <LinkInput
+                type="text"
+                placeholder={
+                  insertItem.title
+                    ? `Paste a ${insertItem.title} link…`
+                    : "Paste a link…"
+                }
+                onKeyDown={this.handleLinkInputKeydown}
+                onPaste={this.handleLinkInputPaste}
+                autoFocus
+              />
+            </LinkInputWrapper>
           ) : (
             <List>
               {items.map((item, index) => {
@@ -383,6 +415,15 @@ class BlockMenu extends React.Component<Props> {
     );
   }
 }
+
+const LinkInputWrapper = styled.div`
+  margin: 8px;
+`;
+
+const LinkInput = styled(Input)`
+  height: 36px;
+  width: 100%;
+`;
 
 const List = styled.ol`
   list-style: none;

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,0 +1,15 @@
+import styled from "styled-components";
+
+const Input = styled.input`
+  font-size: 15px;
+  background: ${props => props.theme.toolbarInput};
+  color: ${props => props.theme.toolbarItem};
+  border-radius: 2px;
+  padding: 4px 8px;
+  border: 0;
+  margin: 0;
+  outline: none;
+  flex-grow: 1;
+`;
+
+export default Input;

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -3,9 +3,9 @@ import styled from "styled-components";
 const Input = styled.input`
   font-size: 15px;
   background: ${props => props.theme.toolbarInput};
-  color: ${props => props.theme.toolbarItem};
+  color: ${props => props.theme.blockToolbarText};
   border-radius: 2px;
-  padding: 4px 8px;
+  padding: 3px 8px;
   border: 0;
   margin: 0;
   outline: none;

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 const Input = styled.input`
   font-size: 15px;
   background: ${props => props.theme.toolbarInput};
-  color: ${props => props.theme.blockToolbarText};
+  color: ${props => props.theme.toolbarItem};
   border-radius: 2px;
   padding: 3px 8px;
   border: 0;

--- a/src/components/LinkEditor.tsx
+++ b/src/components/LinkEditor.tsx
@@ -7,6 +7,7 @@ import styled, { withTheme } from "styled-components";
 import isUrl from "../lib/isUrl";
 import theme from "../theme";
 import Flex from "./Flex";
+import Input from "./Input";
 import ToolbarButton from "./ToolbarButton";
 import LinkSearchResult from "./LinkSearchResult";
 
@@ -234,18 +235,6 @@ const SearchResults = styled.ol`
   margin-top: -3px;
   margin-bottom: 0;
   border-radius: 0 0 4px 4px;
-`;
-
-const Input = styled.input`
-  font-size: 15px;
-  background: ${props => props.theme.toolbarInput};
-  color: ${props => props.theme.toolbarItem};
-  border-radius: 2px;
-  padding: 4px 8px;
-  border: 0;
-  margin: 0;
-  outline: none;
-  flex-grow: 1;
 `;
 
 export default withTheme(LinkEditor);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,6 +14,7 @@ import styled, { ThemeProvider } from "styled-components";
 import { light as lightTheme, dark as darkTheme } from "./theme";
 import Flex from "./components/Flex";
 import { SearchResult } from "./components/LinkEditor";
+import { EmbedDescriptor } from "./types";
 import FloatingToolbar from "./components/FloatingToolbar";
 import BlockMenu from "./components/BlockMenu";
 import Tooltip from "./components/Tooltip";
@@ -85,7 +86,7 @@ export type Props = {
   onClickLink: (href: string) => void;
   onClickHashtag?: (tag: string) => void;
   onKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => void;
-  getLinkComponent?: (href: string) => typeof React.Component | void;
+  embeds: EmbedDescriptor[];
   onShowToast?: (message: string) => void;
   tooltip: typeof React.Component;
   className?: string;
@@ -503,6 +504,7 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
                   onImageUploadStart={this.props.onImageUploadStart}
                   onImageUploadStop={this.props.onImageUploadStop}
                   onShowToast={this.props.onShowToast}
+                  embeds={this.props.embeds}
                 />
               </React.Fragment>
             )}

--- a/src/lib/ExtensionManager.ts
+++ b/src/lib/ExtensionManager.ts
@@ -10,7 +10,7 @@ import Mark from "../marks/Mark";
 
 export default class ExtensionManager {
   extensions: Extension[];
-  getLinkComponent: Function;
+  embeds;
 
   constructor(extensions: Extension[] = [], editor?: Editor) {
     if (editor) {
@@ -20,7 +20,7 @@ export default class ExtensionManager {
     }
 
     this.extensions = extensions;
-    this.getLinkComponent = editor ? editor.props.getLinkComponent : undefined;
+    this.embeds = editor ? editor.props.embeds : undefined;
   }
 
   get nodes() {
@@ -76,7 +76,7 @@ export default class ExtensionManager {
 
     return new MarkdownParser(
       schema,
-      makeRules({ getLinkComponent: this.getLinkComponent }),
+      makeRules({ embeds: this.embeds }),
       tokens
     );
   }

--- a/src/lib/markdown/embeds.ts
+++ b/src/lib/markdown/embeds.ts
@@ -17,14 +17,23 @@ function isLinkClose(token: Token) {
   return token.type === "link_close";
 }
 
-export default function(getLinkComponent) {
+export default function(embeds) {
   function isEmbed(token: Token, link: Token) {
     const href = link.attrs[0][1];
     const simpleLink = href === token.content;
 
     if (!simpleLink) return false;
-    if (!getLinkComponent) return false;
-    return getLinkComponent(href);
+    if (!embeds) return false;
+
+    for (const embed of embeds) {
+      const matches = embed.matcher(href);
+      if (matches) {
+        return {
+          ...embed,
+          matches,
+        };
+      }
+    }
   }
 
   return function markdownEmbeds(md: MarkdownIt) {
@@ -52,14 +61,15 @@ export default function(getLinkComponent) {
             // of hey, we found a link – lets check to see if it should be
             // considered to be an embed
             if (insideLink) {
-              const component = isEmbed(current, insideLink);
-              if (component) {
+              const result = isEmbed(current, insideLink);
+              if (result) {
                 const { content } = current;
 
                 // convert to embed token
                 const token = new Token("embed", "iframe", 0);
                 token.attrSet("href", content);
-                token.attrSet("component", component);
+                token.attrSet("component", result.component);
+                token.attrSet("matches", result.matches);
 
                 // delete the inline link – this makes the assumption that the
                 // embed is the only thing in the para.

--- a/src/lib/markdown/rules.ts
+++ b/src/lib/markdown/rules.ts
@@ -5,16 +5,12 @@ import embedsPlugin from "./embeds";
 import breakPlugin from "./breaks";
 import tablesPlugin from "./tables";
 
-export default function rules({
-  getLinkComponent,
-}: {
-  getLinkComponent: Function;
-}) {
+export default function rules({ embeds }) {
   return markdownit("default", {
     breaks: false,
     html: false,
   })
-    .use(embedsPlugin(getLinkComponent))
+    .use(embedsPlugin(embeds))
     .use(breakPlugin)
     .use(checkboxPlugin)
     .use(markPlugin)

--- a/src/nodes/Embed.tsx
+++ b/src/nodes/Embed.tsx
@@ -13,6 +13,7 @@ export default class Embed extends Node {
       attrs: {
         href: {},
         component: {},
+        matches: {},
       },
       parseDOM: [{ tag: "iframe" }],
       toDOM: node => [
@@ -60,6 +61,7 @@ export default class Embed extends Node {
       node: "embed",
       getAttrs: token => ({
         href: token.attrGet("href"),
+        matches: token.attrGet("matches"),
         component: token.attrGet("component"),
       }),
     };

--- a/src/plugins/MarkdownPaste.ts
+++ b/src/plugins/MarkdownPaste.ts
@@ -31,17 +31,20 @@ export default class MarkdownPaste extends Extension {
               }
 
               // Is this link embedable? Create an embed!
-              const { getLinkComponent } = this.editor.props;
-              const component = getLinkComponent
-                ? getLinkComponent(text)
-                : undefined;
+              const { embeds } = this.editor.props;
 
-              if (component) {
-                this.editor.commands.embed({
-                  href: text,
-                  component,
-                });
-                return true;
+              if (embeds) {
+                for (const embed of embeds) {
+                  const matches = embed.matcher(text);
+                  if (matches) {
+                    this.editor.commands.embed({
+                      href: text,
+                      component: embed.component,
+                      matches,
+                    });
+                    return true;
+                  }
+                }
               }
             }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,9 @@
+import * as React from "react";
+
+export type EmbedDescriptor = {
+  title?: string;
+  name?: string;
+  icon?: React.ReactNode;
+  matcher: (url: string) => boolean | [];
+  component: typeof React.Component;
+};


### PR DESCRIPTION
### Embeds (optionally) appear in block menu…
If `title` and `icon` are provided then the embed will appear in the block menu. This isn't necessary as matching links can be pasted directly – but it exposes what's available to the end user.

![image](https://user-images.githubusercontent.com/380914/82138522-fdcb2a80-97d5-11ea-9d1f-127c1b8b9fc8.png)

### Selecting prompts to paste link…
Hitting enter or clicking in the menu prompts to paste a matching link. A toast will be shown if the pasted link is not accepted.

![image](https://user-images.githubusercontent.com/380914/82138537-18050880-97d6-11ea-8915-a9b26ee049d3.png)

Note: This PR removes `getLinkComponent` interface in favor of this new one. Will merge as a breaking change as part of v10 final.
