### PR TITLE
fix: Parsing of checkbox list items with escaped characters

### DIFF
--- a/src/lib/markdown/checkboxes.ts
+++ b/src/lib/markdown/checkboxes.ts
@@ -32,7 +32,6 @@ export default function markdownItCheckbox(md: MarkdownIt): void {
       const matches = looksLikeChecklist(tokens, i);
       if (matches) {
         const value = matches[1];
-        const label = matches[2];
         const checked = value.toLowerCase() === "x";
 
         // convert surrounding list tokens
@@ -44,9 +43,18 @@ export default function markdownItCheckbox(md: MarkdownIt): void {
           tokens[i + 3].type = "checkbox_list_close";
         }
 
-        // remove [ ] [x] from list item label
-        tokens[i].content = label;
-        tokens[i].children[0].content = label;
+        const tokenChildren = tokens[i].children;
+        if (tokenChildren) {
+          const contentMatches = tokenChildren[0].content.match(CHECKBOX_REGEX);
+
+          if (contentMatches) {
+            const label = contentMatches[2];
+
+            // remove [ ] [x] from list item label
+            tokens[i].content = label;
+            tokenChildren[0].content = label;
+          }
+        }
 
         // open list item and ensure checked state is transferred
         tokens[i - 2].type = "checkbox_item_open";

--- a/src/lib/markdown/checkboxes.ts
+++ b/src/lib/markdown/checkboxes.ts
@@ -43,6 +43,8 @@ export default function markdownItCheckbox(md: MarkdownIt): void {
           tokens[i + 3].type = "checkbox_list_close";
         }
 
+        // remove [ ] [x] from list item label – must use the content from the
+        // child for escaped characters to be unescaped correctly.
         const tokenChildren = tokens[i].children;
         if (tokenChildren) {
           const contentMatches = tokenChildren[0].content.match(CHECKBOX_REGEX);
@@ -50,7 +52,6 @@ export default function markdownItCheckbox(md: MarkdownIt): void {
           if (contentMatches) {
             const label = contentMatches[2];
 
-            // remove [ ] [x] from list item label
             tokens[i].content = label;
             tokenChildren[0].content = label;
           }


### PR DESCRIPTION
closes #203 