### PR TITLE
fix: export extension and don't require onKeyDown listener

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -64,6 +64,8 @@ import MarkdownPaste from "./plugins/MarkdownPaste";
 
 export { schema, parser, serializer } from "./server";
 
+export { default as Extension } from "./lib/Extension";
+
 export const theme = lightTheme;
 
 export type Props = {
@@ -111,6 +113,9 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
     },
     onClickLink: href => {
       window.open(href, "_blank");
+    },
+    onKeyDown: () => {
+      // no default behavior
     },
     embeds: [],
     extensions: [],

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -88,7 +88,7 @@ export type Props = {
   onSearchLink?: (term: string) => Promise<SearchResult[]>;
   onClickLink: (href: string) => void;
   onClickHashtag?: (tag: string) => void;
-  onKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => void;
+  onKeyDown?: (event: React.KeyboardEvent<HTMLDivElement>) => void;
   embeds: EmbedDescriptor[];
   onShowToast?: (message: string) => void;
   tooltip: typeof React.Component;
@@ -113,9 +113,6 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
     },
     onClickLink: href => {
       window.open(href, "_blank");
-    },
-    onKeyDown: () => {
-      // no default behavior
     },
     embeds: [],
     extensions: [],


### PR DESCRIPTION
Add two small API fixes:

* Make `Props.onKeyDown ` an optional prop by providing a no-op default callback. While the callback is useful, most users probably don't want to add their own `onKeyDown` listener.
* Export the `Extension` class. While `Props.extensions` is exposed, users can't really create their own extensions because the `Extension` class is not exported.

