### PR TITLE
feat: Trigger link editor from block menu

### DIFF
--- a/src/components/BlockMenu.tsx
+++ b/src/components/BlockMenu.tsx
@@ -11,6 +11,7 @@ import VisuallyHidden from "./VisuallyHidden";
 import getDataTransferFiles from "../lib/getDataTransferFiles";
 import insertFiles from "../commands/insertFiles";
 import getMenuItems from "../menus/block";
+
 const SSR = typeof window === "undefined";
 
 type Props = {
@@ -22,6 +23,7 @@ type Props = {
   onImageUploadStart?: () => void;
   onImageUploadStop?: () => void;
   onShowToast?: (message: string, id: string) => void;
+  onLinkToolbarOpen: () => void;
   onClose: () => void;
   embeds: EmbedDescriptor[];
 };
@@ -90,14 +92,9 @@ class BlockMenu extends React.Component<Props, State> {
       event.stopPropagation();
 
       const item = this.filtered[this.state.selectedIndex];
+
       if (item) {
-        if (item.name === "image") {
-          this.triggerImagePick();
-        } else if (item.name === "embed") {
-          this.triggerLinkInput(item);
-        } else {
-          this.insertBlock(item);
-        }
+        this.insertItem(item);
       } else {
         this.props.onClose();
       }
@@ -148,6 +145,23 @@ class BlockMenu extends React.Component<Props, State> {
 
     if (event.key === "Escape") {
       this.close();
+    }
+  };
+
+  insertItem = item => {
+    switch (item.name) {
+      case "image":
+        return this.triggerImagePick();
+      case "embed":
+        return this.triggerLinkInput(item);
+      case "link": {
+        this.clearSearch();
+        this.props.onClose();
+        this.props.onLinkToolbarOpen();
+        return;
+      }
+      default:
+        this.insertBlock(item);
     }
   };
 
@@ -256,7 +270,7 @@ class BlockMenu extends React.Component<Props, State> {
     this.props.onClose();
   };
 
-  insertBlock(item) {
+  clearSearch() {
     const { state, dispatch } = this.props.view;
     const parent = findParentNode(node => !!node)(state.selection);
 
@@ -269,6 +283,10 @@ class BlockMenu extends React.Component<Props, State> {
         )
       );
     }
+  }
+
+  insertBlock(item) {
+    this.clearSearch();
 
     const command = this.props.commands[item.name];
     if (command) {
@@ -415,16 +433,7 @@ class BlockMenu extends React.Component<Props, State> {
                 return (
                   <ListItem key={index}>
                     <BlockMenuItem
-                      onClick={() => {
-                        switch (item.name) {
-                          case "image":
-                            return this.triggerImagePick();
-                          case "embed":
-                            return this.triggerLinkInput(item);
-                          default:
-                            this.insertBlock(item);
-                        }
-                      }}
+                      onClick={() => this.insertItem(item)}
                       selected={selected}
                       icon={item.icon}
                       title={item.title}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -553,6 +553,7 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
                   search={this.state.blockMenuSearch}
                   onClose={this.handleCloseBlockMenu}
                   uploadImage={this.props.uploadImage}
+                  onLinkToolbarOpen={this.handleOpenLinkMenu}
                   onImageUploadStart={this.props.onImageUploadStart}
                   onImageUploadStop={this.props.onImageUploadStop}
                   onShowToast={this.props.onShowToast}

--- a/src/menus/block.ts
+++ b/src/menus/block.ts
@@ -10,8 +10,12 @@ import {
   TableIcon,
   TodoListIcon,
   ImageIcon,
+  LinkIcon,
 } from "outline-icons";
 import { MenuItem } from "../types";
+
+const isMac = window && window.navigator.platform === "MacIntel";
+const mod = isMac ? "⌘" : "ctrl";
 
 export default function blockMenuItems(): MenuItem[] {
   return [
@@ -74,7 +78,7 @@ export default function blockMenuItems(): MenuItem[] {
       name: "blockquote",
       title: "Quote",
       icon: BlockQuoteIcon,
-      shortcut: "⌘ ]",
+      shortcut: `${mod} ]`,
       attrs: { level: 2 },
     },
     {
@@ -88,7 +92,7 @@ export default function blockMenuItems(): MenuItem[] {
       name: "hr",
       title: "Divider",
       icon: HorizontalRuleIcon,
-      shortcut: "⌘ _",
+      shortcut: `${mod} _`,
       keywords: "horizontal rule break line",
     },
     {
@@ -96,6 +100,13 @@ export default function blockMenuItems(): MenuItem[] {
       title: "Image",
       icon: ImageIcon,
       keywords: "picture photo",
+    },
+    {
+      name: "link",
+      title: "Link",
+      icon: LinkIcon,
+      shortcut: `${mod} k`,
+      keywords: "link url uri href",
     },
   ];
 }


### PR DESCRIPTION
feat: Trigger link editor from block menu
fix: macOS shortcuts showing on windows
refactor: DRY up item creation that was duplicated between keyboard/mouse events
