### PR TITLE
feat: add dom event callback functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ This object maps [event](https://developer.mozilla.org/en-US/docs/Web/Events) na
 <Editor
   handleDOMEvents={{
     focus: () => console.log("FOCUS"),
-    blur: console.log("BLUR"),
+    blur: () => console.log("BLUR"),
     paste: () => console.log("PASTE"),
     touchstart: () => console.log("TOUCH START"),
   }}

--- a/README.md
+++ b/README.md
@@ -199,6 +199,21 @@ import { history } from "react-router";
 />
 ```
 
+#### `handleDOMEvents: {[name: string]: (view: EditorView, event: Event) => boolean;}`
+
+This object maps [event](https://developer.mozilla.org/en-US/docs/Web/Events) names (`focus`, `paste`, `touchstart`, etc.) to callback functions.
+
+```javascript
+<Editor
+  handleDOMEvents={{
+    focus: () => console.log("FOCUS"),
+    blur: console.log("BLUR"),
+    paste: () => console.log("PASTE"),
+    touchstart: () => console.log("TOUCH START"),
+  }}
+/>
+```
+
 ### Interface
 
 The Editor component exposes a few methods for interacting with the mounted editor.

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -104,6 +104,12 @@ class Example extends React.Component {
           readOnly={this.state.readOnly}
           value={this.state.value}
           defaultValue={defaultValue}
+          handleDOMEvents={{
+            focus: () => console.log("FOCUS"),
+            blur: console.log("BLUR"),
+            paste: () => console.log("PASTE"),
+            touchstart: () => console.log("TOUCH START"),
+          }}
           onSave={options => console.log("Save triggered", options)}
           onCancel={() => console.log("Cancel triggered")}
           onChange={this.handleChange}

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -106,7 +106,7 @@ class Example extends React.Component {
           defaultValue={defaultValue}
           handleDOMEvents={{
             focus: () => console.log("FOCUS"),
-            blur: console.log("BLUR"),
+            blur: () => console.log("BLUR"),
             paste: () => console.log("PASTE"),
             touchstart: () => console.log("TOUCH START"),
           }}

--- a/src/commands/createAndInsertLink.ts
+++ b/src/commands/createAndInsertLink.ts
@@ -63,7 +63,7 @@ const createAndInsertLink = async function(
     );
   } catch (err) {
     const result = findPlaceholderLink(view.state.doc, href);
-if (!result) return;
+    if (!result) return;
 
     dispatch(
       view.state.tr.removeMark(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -80,6 +80,9 @@ export type Props = {
   dark?: boolean;
   theme?: typeof theme;
   headingsOffset?: number;
+  handleDOMEvents?: {
+    [name: string]: (view: EditorView, event: Event) => boolean;
+  };
   uploadImage?: (file: File) => Promise<string>;
   onSave?: ({ done: boolean }) => void;
   onCancel?: () => void;
@@ -368,6 +371,7 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
       state: this.createState(),
       editable: () => !this.props.readOnly,
       nodeViews: this.nodeViews,
+      handleDOMEvents: this.props.handleDOMEvents,
       dispatchTransaction: transaction => {
         const { state, transactions } = this.view.state.applyTransaction(
           transaction


### PR DESCRIPTION
Solves #223

Another possibility would be to expose a prop `editorViewProps` that would just pass everything directly to `EditorView`. 🤷‍♂️