### PR TITLE
feat: Adds support for "templates"

### DIFF
--- a/example/src/index.js
+++ b/example/src/index.js
@@ -93,13 +93,13 @@ class Example extends React.Component {
         <div>
           <br />
           <button type="button" onClick={this.handleToggleReadOnly}>
-            {this.state.readOnly ? "Editable" : "Read only"}
+            {this.state.readOnly ? "Switch to Editable" : "Switch to Read-only"}
           </button>{" "}
           <button type="button" onClick={this.handleToggleDark}>
-            {this.state.dark ? "Light theme" : "Dark theme"}
+            {this.state.dark ? "Switch to Light" : "Switch to Dark"}
           </button>{" "}
           <button type="button" onClick={this.handleToggleTemplate}>
-            {this.state.template ? "Regular doc" : "Template doc"}
+            {this.state.template ? "Switch to Document" : "Switch to Template"}
           </button>{" "}
           <button type="button" onClick={this.handleUpdateValue}>
             Update value

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -51,12 +51,17 @@ class YoutubeEmbed extends React.Component {
 class Example extends React.Component {
   state = {
     readOnly: false,
+    template: false,
     dark: localStorage.getItem("dark") === "enabled",
     value: undefined,
   };
 
   handleToggleReadOnly = () => {
     this.setState({ readOnly: !this.state.readOnly });
+  };
+
+  handleToggleTemplate = () => {
+    this.setState({ template: !this.state.template });
   };
 
   handleToggleDark = () => {
@@ -93,6 +98,9 @@ class Example extends React.Component {
           <button type="button" onClick={this.handleToggleDark}>
             {this.state.dark ? "Light theme" : "Dark theme"}
           </button>{" "}
+          <button type="button" onClick={this.handleToggleTemplate}>
+            {this.state.template ? "Regular doc" : "Template doc"}
+          </button>{" "}
           <button type="button" onClick={this.handleUpdateValue}>
             Update value
           </button>
@@ -104,6 +112,7 @@ class Example extends React.Component {
           readOnly={this.state.readOnly}
           readOnlyWriteCheckboxes
           value={this.state.value}
+          template={this.state.template}
           defaultValue={defaultValue}
           scrollTo={window.location.hash}
           handleDOMEvents={{

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lodash": "^4.17.11",
     "markdown-it-container": "^3.0.0",
     "markdown-it-mark": "^3.0.0",
-    "outline-icons": "^1.21.0-0",
+    "outline-icons": "^1.21.0-1",
     "prismjs": "^1.19.0",
     "prosemirror-commands": "^1.1.4",
     "prosemirror-dropcursor": "^1.3.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rich-markdown-editor",
   "description": "A rich text editor with Markdown shortcuts",
-  "version": "10.4.0",
+  "version": "10.5.0-0",
   "main": "dist/lib/index.js",
   "typings": "dist/@types/index.d.ts",
   "license": "BSD-3-Clause",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lodash": "^4.17.11",
     "markdown-it-container": "^3.0.0",
     "markdown-it-mark": "^3.0.0",
-    "outline-icons": "^1.21.0-1",
+    "outline-icons": "^1.21.0-3",
     "prismjs": "^1.19.0",
     "prosemirror-commands": "^1.1.4",
     "prosemirror-dropcursor": "^1.3.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lodash": "^4.17.11",
     "markdown-it-container": "^3.0.0",
     "markdown-it-mark": "^3.0.0",
-    "outline-icons": "^1.19.1",
+    "outline-icons": "^1.21.0-0",
     "prismjs": "^1.19.0",
     "prosemirror-commands": "^1.1.4",
     "prosemirror-dropcursor": "^1.3.2",

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -20,14 +20,16 @@ class Menu extends React.Component<Props> {
     const { state } = view;
     const Tooltip = this.props.tooltip;
 
+    console.log(this.props.commands);
+
     return (
       <div>
         {items.map((item, index) => {
+          if (item.name === "separator" && item.visible !== false) {
+            return <ToolbarSeparator key={index} />;
+          }
           if (item.visible === false || !item.icon) {
             return null;
-          }
-          if (item.name === "separator") {
-            return <ToolbarSeparator key={index} />;
           }
           const Icon = item.icon;
           const isActive = item.active ? item.active(state) : false;

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -20,8 +20,6 @@ class Menu extends React.Component<Props> {
     const { state } = view;
     const Tooltip = this.props.tooltip;
 
-    console.log(this.props.commands);
-
     return (
       <div>
         {items.map((item, index) => {

--- a/src/components/SelectionToolbar.tsx
+++ b/src/components/SelectionToolbar.tsx
@@ -19,6 +19,7 @@ import { MenuItem } from "../types";
 
 type Props = {
   tooltip: typeof React.Component;
+  isTemplate: boolean;
   commands: Record<string, any>;
   onSearchLink?: (term: string) => Promise<SearchResult[]>;
   onClickLink: (url: string) => void;
@@ -84,7 +85,7 @@ export default class SelectionToolbar extends React.Component<Props> {
   };
 
   render() {
-    const { onCreateLink, ...rest } = this.props;
+    const { onCreateLink, isTemplate, ...rest } = this.props;
     const { view } = rest;
     const { state } = view;
     const { selection }: { selection: any } = state;
@@ -109,7 +110,7 @@ export default class SelectionToolbar extends React.Component<Props> {
     } else if (rowIndex !== undefined) {
       items = getTableRowMenuItems(state, rowIndex);
     } else {
-      items = getFormattingMenuItems(state);
+      items = getFormattingMenuItems(state, isTemplate);
     }
 
     if (!items.length) {

--- a/src/components/ToolbarSeparator.tsx
+++ b/src/components/ToolbarSeparator.tsx
@@ -4,7 +4,7 @@ const Separator = styled.div`
   height: 24px;
   width: 2px;
   background: ${props => props.theme.toolbarItem};
-  opacity: 0.1;
+  opacity: 0.3;
   display: inline-block;
   margin-left: 10px;
 `;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -861,7 +861,20 @@ const StyledEditor = styled("div")<{
   }
 
   .template-placeholder {
-    background: red;
+    color: ${props => props.theme.placeholder};
+    border-bottom: 1px dotted ${props => props.theme.placeholder};
+    border-radius: 2px;
+    cursor: text;
+
+    &:hover {
+      border-bottom: 1px dotted ${props => props.theme.textSecondary};
+    }
+
+    &:focus {
+      margin: -2px;
+      padding: 2px;
+      border: 1px solid ${props => props.theme.placeholder};
+    }
   }
 
   p {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -867,13 +867,9 @@ const StyledEditor = styled("div")<{
     cursor: text;
 
     &:hover {
-      border-bottom: 1px dotted ${props => props.theme.textSecondary};
-    }
-
-    &:focus {
-      margin: -2px;
-      padding: 2px;
-      border: 1px solid ${props => props.theme.placeholder};
+      border-bottom: 1px dotted
+        ${props =>
+          props.readOnly ? props.theme.placeholder : props.theme.textSecondary};
     }
   }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -54,6 +54,7 @@ import Highlight from "./marks/Highlight";
 import Italic from "./marks/Italic";
 import Link from "./marks/Link";
 import Strikethrough from "./marks/Strikethrough";
+import TemplatePlaceholder from "./marks/Placeholder";
 
 // plugins
 import BlockMenuTrigger from "./plugins/BlockMenuTrigger";
@@ -81,6 +82,7 @@ export type Props = {
   readOnlyWriteCheckboxes?: boolean;
   dark?: boolean;
   theme?: typeof theme;
+  template?: boolean;
   headingsOffset?: number;
   scrollTo?: string;
   handleDOMEvents?: {
@@ -256,6 +258,7 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
         new Code(),
         new Highlight(),
         new Italic(),
+        new TemplatePlaceholder(),
         new Link({
           onKeyboardShortcut: this.handleOpenLinkMenu,
           onClickLink: this.props.onClickLink,
@@ -574,6 +577,7 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
                 <SelectionToolbar
                   view={this.view}
                   commands={this.commands}
+                  isTemplate={this.props.template === true}
                   onSearchLink={this.props.onSearchLink}
                   onClickLink={this.props.onClickLink}
                   onCreateLink={this.props.onCreateLink}
@@ -854,6 +858,10 @@ const StyledEditor = styled("div")<{
   b,
   strong {
     font-weight: 600;
+  }
+
+  .template-placeholder {
+    background: red;
   }
 
   p {

--- a/src/lib/markdown/placeholders.ts
+++ b/src/lib/markdown/placeholders.ts
@@ -50,7 +50,6 @@ export default function placeholderPlugin(md) {
     }
 
     state.pos += scanned.length;
-    console.log({ state });
     return true;
   }
 
@@ -63,8 +62,6 @@ export default function placeholderPlugin(md) {
 
     for (i = 0; i < max; i++) {
       startDelim = delimiters[i];
-
-      console.log({ startDelim });
 
       if (startDelim.marker !== 33) {
         continue;

--- a/src/lib/markdown/placeholders.ts
+++ b/src/lib/markdown/placeholders.ts
@@ -1,0 +1,138 @@
+// Adapted from:
+// https://github.com/markdown-it/markdown-it-mark/blob/master/index.js
+
+export default function placeholderPlugin(md) {
+  function tokenize(state, silent) {
+    let i, token;
+
+    const start = state.pos,
+      marker = state.src.charCodeAt(start);
+
+    if (silent) {
+      return false;
+    }
+
+    if (marker !== 33) {
+      return false;
+    }
+
+    const scanned = state.scanDelims(state.pos, true);
+    const ch = String.fromCharCode(marker);
+    let len = scanned.length;
+
+    if (len < 2) {
+      return false;
+    }
+
+    if (len % 2) {
+      token = state.push("text", "", 0);
+      token.content = ch;
+      len--;
+    }
+
+    for (i = 0; i < len; i += 2) {
+      token = state.push("text", "", 0);
+      token.content = ch + ch;
+
+      if (!scanned.can_open && !scanned.can_close) {
+        continue;
+      }
+
+      state.delimiters.push({
+        marker,
+        length: 0, // disable "rule of 3" length checks meant for emphasis
+        jump: i,
+        token: state.tokens.length - 1,
+        end: -1,
+        open: scanned.can_open,
+        close: scanned.can_close,
+      });
+    }
+
+    state.pos += scanned.length;
+    console.log({ state });
+    return true;
+  }
+
+  // Walk through delimiter list and replace text tokens with tags
+  //
+  function postProcess(state, delimiters) {
+    let i, j, startDelim, endDelim, token;
+    const loneMarkers: number[] = [],
+      max = delimiters.length;
+
+    for (i = 0; i < max; i++) {
+      startDelim = delimiters[i];
+
+      console.log({ startDelim });
+
+      if (startDelim.marker !== 33) {
+        continue;
+      }
+
+      if (startDelim.end === -1) {
+        continue;
+      }
+
+      endDelim = delimiters[startDelim.end];
+
+      token = state.tokens[startDelim.token];
+      token.type = "placeholder_open";
+      token.tag = "span";
+      token.nesting = 1;
+      token.markup = "!!";
+      token.content = "";
+
+      token = state.tokens[endDelim.token];
+      token.type = "placeholder_close";
+      token.tag = "span";
+      token.nesting = -1;
+      token.markup = "!!";
+      token.content = "";
+
+      if (
+        state.tokens[endDelim.token - 1].type === "text" &&
+        state.tokens[endDelim.token - 1].content === "!"
+      ) {
+        loneMarkers.push(endDelim.token - 1);
+      }
+    }
+
+    // If a marker sequence has an odd number of characters, it's splitted
+    // like this: `~~~~~` -> `~` + `~~` + `~~`, leaving one marker at the
+    // start of the sequence.
+    //
+    // So, we have to move all those markers after subsequent s_close tags.
+    while (loneMarkers.length) {
+      i = loneMarkers.pop();
+      j = i + 1;
+
+      while (j < state.tokens.length && state.tokens[j].type === "mark_close") {
+        j++;
+      }
+
+      j--;
+
+      if (i !== j) {
+        token = state.tokens[j];
+        state.tokens[j] = state.tokens[i];
+        state.tokens[i] = token;
+      }
+    }
+  }
+
+  md.inline.ruler.before("emphasis", "placeholder", tokenize);
+  md.inline.ruler2.before("emphasis", "placeholder", function(state) {
+    let curr;
+    const tokensMeta = state.tokens_meta,
+      max = (state.tokens_meta || []).length;
+
+    postProcess(state, state.delimiters);
+
+    for (curr = 0; curr < max; curr++) {
+      if (tokensMeta[curr] && tokensMeta[curr].delimiters) {
+        postProcess(state, tokensMeta[curr].delimiters);
+      }
+    }
+  });
+}

--- a/src/lib/markdown/rules.ts
+++ b/src/lib/markdown/rules.ts
@@ -1,5 +1,6 @@
 import markdownit from "markdown-it";
 import markPlugin from "markdown-it-mark";
+import placeholderPlugin from "./placeholders";
 import checkboxPlugin from "./checkboxes";
 import embedsPlugin from "./embeds";
 import breakPlugin from "./breaks";
@@ -15,6 +16,7 @@ export default function rules({ embeds }) {
     .use(breakPlugin)
     .use(checkboxPlugin)
     .use(markPlugin)
+    .use(placeholderPlugin)
     .use(tablesPlugin)
     .use(noticesPlugin);
 }

--- a/src/marks/Placeholder.ts
+++ b/src/marks/Placeholder.ts
@@ -67,6 +67,9 @@ export default class Placeholder extends Mark {
             if (this.editor.props.template) {
               return false;
             }
+            if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") {
+              return false;
+            }
 
             const { state, dispatch } = view;
 
@@ -74,8 +77,6 @@ export default class Placeholder extends Mark {
               state.selection.$from,
               state.schema.marks.placeholder
             );
-            if (event.key === "ArrowDown" || event.key === "ArrowUp")
-              return false;
             if (!range) return false;
 
             if (event.key === "ArrowRight") {

--- a/src/marks/Placeholder.ts
+++ b/src/marks/Placeholder.ts
@@ -67,25 +67,56 @@ export default class Placeholder extends Mark {
             if (this.editor.props.template) {
               return false;
             }
-            if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") {
+            if (
+              event.key !== "ArrowLeft" &&
+              event.key !== "ArrowRight" &&
+              event.key !== "Backspace"
+            ) {
               return false;
             }
 
             const { state, dispatch } = view;
 
-            const range = getMarkRange(
-              state.selection.$from,
-              state.schema.marks.placeholder
-            );
-            if (!range) return false;
+            if (event.key === "Backspace") {
+              const range = getMarkRange(
+                state.doc.resolve(state.selection.from - 1),
+                state.schema.marks.placeholder
+              );
+              if (!range) return false;
 
-            if (event.key === "ArrowRight") {
-              const endOfMark = state.doc.resolve(range.to);
-              dispatch(state.tr.setSelection(TextSelection.near(endOfMark)));
+              dispatch(
+                state.tr
+                  .removeMark(
+                    range.from,
+                    range.to,
+                    state.schema.marks.placeholder
+                  )
+                  .insertText("", range.from, range.to)
+              );
               return true;
-            } else if (event.key === "ArrowLeft") {
+            }
+
+            if (event.key === "ArrowLeft") {
+              const range = getMarkRange(
+                state.doc.resolve(state.selection.from - 1),
+                state.schema.marks.placeholder
+              );
+              if (!range) return false;
+
               const startOfMark = state.doc.resolve(range.from);
               dispatch(state.tr.setSelection(TextSelection.near(startOfMark)));
+              return true;
+            }
+
+            if (event.key === "ArrowRight") {
+              const range = getMarkRange(
+                state.selection.$from,
+                state.schema.marks.placeholder
+              );
+              if (!range) return false;
+
+              const endOfMark = state.doc.resolve(range.to);
+              dispatch(state.tr.setSelection(TextSelection.near(endOfMark)));
               return true;
             }
 

--- a/src/marks/Placeholder.ts
+++ b/src/marks/Placeholder.ts
@@ -1,0 +1,33 @@
+import { toggleMark } from "prosemirror-commands";
+import markInputRule from "../lib/markInputRule";
+import Mark from "./Mark";
+
+export default class Placeholder extends Mark {
+  get name() {
+    return "placeholder";
+  }
+
+  get schema() {
+    return {
+      parseDOM: [{ tag: "span.template-placeholder" }],
+      toDOM: () => ["span", { class: "template-placeholder" }],
+    };
+  }
+
+  inputRules({ type }) {
+    return [markInputRule(/(?:\<\<)([^<>]+)(?:\>\>)$/, type)];
+  }
+
+  get toMarkdown() {
+    return {
+      open: "<<",
+      close: ">>",
+      mixable: true,
+      expelEnclosingWhitespace: true,
+    };
+  }
+
+  parseMarkdown() {
+    return { mark: "placeholder" };
+  }
+}

--- a/src/marks/Placeholder.ts
+++ b/src/marks/Placeholder.ts
@@ -1,4 +1,3 @@
-import { toggleMark } from "prosemirror-commands";
 import markInputRule from "../lib/markInputRule";
 import Mark from "./Mark";
 
@@ -15,13 +14,13 @@ export default class Placeholder extends Mark {
   }
 
   inputRules({ type }) {
-    return [markInputRule(/(?:\<\<)([^<>]+)(?:\>\>)$/, type)];
+    return [markInputRule(/(?:\!)([^!]+)(?:\!)$/, type)];
   }
 
   get toMarkdown() {
     return {
-      open: "<<",
-      close: ">>",
+      open: "!!",
+      close: "!!",
       mixable: true,
       expelEnclosingWhitespace: true,
     };

--- a/src/menus/formatting.ts
+++ b/src/menus/formatting.ts
@@ -7,6 +7,7 @@ import {
   BlockQuoteIcon,
   LinkIcon,
   StrikethroughIcon,
+  QuestionMarkIcon,
   HighlightIcon,
 } from "outline-icons";
 import { isInTable } from "prosemirror-tables";
@@ -16,13 +17,27 @@ import isMarkActive from "../queries/isMarkActive";
 import isNodeActive from "../queries/isNodeActive";
 import { MenuItem } from "../types";
 
-export default function formattingMenuItems(state: EditorState): MenuItem[] {
+export default function formattingMenuItems(
+  state: EditorState,
+  isTemplate: boolean
+): MenuItem[] {
   const { schema } = state;
   const isTable = isInTable(state);
   const isList = isInList(state);
   const allowBlocks = !isTable && !isList;
 
   return [
+    {
+      name: "placeholder",
+      tooltip: "Placeholder",
+      icon: QuestionMarkIcon,
+      active: isMarkActive(schema.marks.placeholder),
+      visible: isTemplate,
+    },
+    {
+      name: "separator",
+      visible: isTemplate,
+    },
     {
       name: "strong",
       tooltip: "Bold",
@@ -46,6 +61,7 @@ export default function formattingMenuItems(state: EditorState): MenuItem[] {
       tooltip: "Highlight",
       icon: HighlightIcon,
       active: isMarkActive(schema.marks.mark),
+      visible: !isTemplate,
     },
     {
       name: "code_inline",

--- a/src/menus/formatting.ts
+++ b/src/menus/formatting.ts
@@ -7,7 +7,7 @@ import {
   BlockQuoteIcon,
   LinkIcon,
   StrikethroughIcon,
-  QuestionMarkIcon,
+  InputIcon,
   HighlightIcon,
 } from "outline-icons";
 import { isInTable } from "prosemirror-tables";
@@ -30,7 +30,7 @@ export default function formattingMenuItems(
     {
       name: "placeholder",
       tooltip: "Placeholder",
-      icon: QuestionMarkIcon,
+      icon: InputIcon,
       active: isMarkActive(schema.marks.placeholder),
       visible: isTemplate,
     },

--- a/src/plugins/Placeholder.ts
+++ b/src/plugins/Placeholder.ts
@@ -4,7 +4,7 @@ import Extension from "../lib/Extension";
 
 export default class Placeholder extends Extension {
   get name() {
-    return "placeholder";
+    return "empty-placeholder";
   }
 
   get defaultOptions() {

--- a/src/server.ts
+++ b/src/server.ts
@@ -30,6 +30,7 @@ import Highlight from "./marks/Highlight";
 import Italic from "./marks/Italic";
 import Link from "./marks/Link";
 import Strikethrough from "./marks/Strikethrough";
+import TemplatePlaceholder from "./marks/Placeholder";
 
 const extensions = new ExtensionManager([
   new Doc(),
@@ -57,6 +58,7 @@ const extensions = new ExtensionManager([
   new Italic(),
   new Link(),
   new Strikethrough(),
+  new TemplatePlaceholder(),
   new OrderedList(),
 ]);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4039,10 +4039,10 @@ os-tmpdir@~1.0.2:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
-outline-icons@^1.21.0-0:
-  version "1.21.0-0"
-  resolved "https://registry.yarnpkg.com/outline-icons/-/outline-icons-1.21.0-0.tgz#91c85fa4837200aa88f701d7b4a4be5d31a6c3a6"
-  integrity sha512-q+Wf4pUhz8YaMIfxoUOsSQYVqPXdIL4nTwUD4wbSWz3G+rKDfwPtZWvi3J1RnXODLMXvXfuvwHSc3DdW6N4FbQ==
+outline-icons@^1.21.0-1:
+  version "1.21.0-1"
+  resolved "https://registry.yarnpkg.com/outline-icons/-/outline-icons-1.21.0-1.tgz#dc9bf2bbb5b5c7f3513c245de8e77e67dcf4a136"
+  integrity sha512-M6Ptn8kfo06J8XIdk9TW9KvKkZOq4V57HdaGwx+3i0Wbur1/0CyrapBbGFHjGUBCiD8MMkcGzY7hTPqM2Y/svA==
 
 p-defer@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4039,10 +4039,10 @@ os-tmpdir@~1.0.2:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
-outline-icons@^1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/outline-icons/-/outline-icons-1.19.1.tgz#5251b966ae9987b18f060b58ce469d248c2313aa"
-  integrity sha512-YeGLDG7KgBvrDy+WOQUqN8rD3qO5u524E0Wj6ejaWNQ8/1ou6kkUrx65mk8LtESfKLMWZHuQG/u6onurY9rKIw==
+outline-icons@^1.21.0-0:
+  version "1.21.0-0"
+  resolved "https://registry.yarnpkg.com/outline-icons/-/outline-icons-1.21.0-0.tgz#91c85fa4837200aa88f701d7b4a4be5d31a6c3a6"
+  integrity sha512-q+Wf4pUhz8YaMIfxoUOsSQYVqPXdIL4nTwUD4wbSWz3G+rKDfwPtZWvi3J1RnXODLMXvXfuvwHSc3DdW6N4FbQ==
 
 p-defer@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4039,10 +4039,10 @@ os-tmpdir@~1.0.2:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
-outline-icons@^1.21.0-1:
-  version "1.21.0-1"
-  resolved "https://registry.yarnpkg.com/outline-icons/-/outline-icons-1.21.0-1.tgz#dc9bf2bbb5b5c7f3513c245de8e77e67dcf4a136"
-  integrity sha512-M6Ptn8kfo06J8XIdk9TW9KvKkZOq4V57HdaGwx+3i0Wbur1/0CyrapBbGFHjGUBCiD8MMkcGzY7hTPqM2Y/svA==
+outline-icons@^1.21.0-3:
+  version "1.21.0-3"
+  resolved "https://registry.yarnpkg.com/outline-icons/-/outline-icons-1.21.0-3.tgz#136bdcc9718fd4a4ebac09c2ad6f2bb1c7bdb9af"
+  integrity sha512-hUIb9VFTbob9TbLghzCeUKV/cWp+FN1xZfHhSqIQIIfH3F3Pmc5RjkT61iSSKiAGRo4ERGz8MPtHaAO1LostWg==
 
 p-defer@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Template documents include an additional formatting option to mark text as a placeholder (on the far left).
![image](https://user-images.githubusercontent.com/380914/88490416-51818f00-cf50-11ea-8f4c-57bb750b6fc8.png)


When not viewing as a template, placeholders act like input fields for the user to replace.
![image](https://user-images.githubusercontent.com/380914/88488704-e29e3900-cf43-11ea-80f1-aa2e0c34c34d.png)
