### PR TITLE
fix: Combination of inline styles and breaks within table cells

### DIFF
--- a/src/lib/markdown/tables.ts
+++ b/src/lib/markdown/tables.ts
@@ -14,20 +14,26 @@ export default function markdownTables(md: MarkdownIt) {
 
       // convert break line into br tag
       if (tokens[i].type === "inline" && tokens[i].content.includes("\\n")) {
-        const nodes: Token[] = [];
-        const breakParts = tokens[i].content.split("\\n");
-        breakParts.forEach((part, index) => {
-          const token = new Token("text", "", 1);
-          token.content = part.trim();
-          nodes.push(token);
+        const existing = tokens[i].children || [];
+        tokens[i].children = [];
 
-          if (index < breakParts.length - 1) {
-            const brToken = new Token("br", "br", 1);
-            nodes.push(brToken);
+        existing.forEach(child => {
+          if (child.content.includes("\\n")) {
+            const breakParts = child.content.split("\\n");
+            breakParts.forEach((part, index) => {
+              const token = new Token("text", "", 1);
+              token.content = part.trim();
+              tokens[i].children?.push(token);
+
+              if (index < breakParts.length - 1) {
+                const brToken = new Token("br", "br", 1);
+                tokens[i].children?.push(brToken);
+              }
+            });
+          } else {
+            tokens[i].children?.push(child);
           }
         });
-
-        tokens.splice(i, 1, ...nodes);
       }
 
       // filter out incompatible tokens from markdown-it that we don't need


### PR DESCRIPTION
Move the breaking of children down a level to take into account marks.

closes #264 