### PR TITLE
fix: Toolbar maximum update depth exceeded

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react-medium-image-zoom": "^3.0.16",
     "react-portal": "^4.2.1",
     "refractor": "^3.1.0",
+    "resize-observer-polyfill": "^1.5.1",
     "slugify": "^1.4.0",
     "smooth-scroll-into-view-if-needed": "^1.1.27",
     "styled-components": "^5.1.0",

--- a/src/components/FloatingToolbar.tsx
+++ b/src/components/FloatingToolbar.tsx
@@ -60,24 +60,29 @@ function usePosition({ menuRef, isSelectingText, props }) {
   const toPos = view.coordsAtPos(selection.$to.pos);
 
   // ensure that start < end for the menu to be positioned correctly
-  const startPos = fromPos.left < toPos.left ? fromPos : toPos;
-  const endPos = fromPos.left < toPos.left ? toPos : fromPos;
+  const selectionBounds = {
+    top: Math.min(fromPos.top, toPos.top),
+    bottom: Math.max(fromPos.bottom, toPos.bottom),
+    left: Math.min(fromPos.left, toPos.left),
+    right: Math.max(fromPos.right, toPos.right),
+  };
 
   // tables are an oddity, and need their own logic
   const isColSelection = selection.isColSelection && selection.isColSelection();
   const isRowSelection = selection.isRowSelection && selection.isRowSelection();
 
   if (isRowSelection) {
-    endPos.left = startPos.left + 12;
+    selectionBounds.right = selectionBounds.left + 12;
   } else if (isColSelection) {
     const { node: element } = view.domAtPos(selection.$from.pos);
     const { width } = element.getBoundingClientRect();
-    endPos.left = startPos.left + width;
+    selectionBounds.right = selectionBounds.left + width;
   }
 
   // calcluate the horizontal center of the selection
-  const halfSelection = Math.abs(endPos.left - startPos.left) / 2;
-  const centerOfSelection = startPos.left + halfSelection;
+  const halfSelection =
+    Math.abs(selectionBounds.right - selectionBounds.left) / 2;
+  const centerOfSelection = selectionBounds.left + halfSelection;
 
   // position the menu so that it is centered over the selection except in
   // the cases where it would extend off the edge of the screen. In these
@@ -89,7 +94,7 @@ function usePosition({ menuRef, isSelectingText, props }) {
   );
   const top = Math.min(
     window.innerHeight - menuHeight - margin,
-    Math.max(margin, Math.min(startPos.top, fromPos.top) - menuHeight)
+    Math.max(margin, selectionBounds.top - menuHeight)
   );
 
   // if the menu has been offset to not extend offscreen then we should adjust

--- a/src/components/FloatingToolbar.tsx
+++ b/src/components/FloatingToolbar.tsx
@@ -1,6 +1,6 @@
+import ResizeObserver from "resize-observer-polyfill";
 import * as React from "react";
 import { Portal } from "react-portal";
-import { isEqual } from "lodash";
 import { EditorView } from "prosemirror-view";
 import styled from "styled-components";
 
@@ -13,130 +13,144 @@ type Props = {
   forwardedRef?: React.RefObject<HTMLDivElement> | null;
 };
 
-class FloatingToolbar extends React.Component<Props> {
-  menuRef = this.props.forwardedRef || React.createRef<HTMLDivElement>();
+const defaultPosition = {
+  left: -1000,
+  top: 0,
+  offset: 0,
+  visible: false,
+};
 
-  state = {
-    left: -1000,
-    top: 0,
-    offset: 0,
-    visible: false,
-    isSelectingText: false,
-  };
+const useComponentSize = comRef => {
+  const [size, setSize] = React.useState({
+    width: 0,
+    height: 0,
+  });
 
-  componentDidMount() {
-    window.addEventListener("mousedown", this.handleMouseDown);
-    window.addEventListener("mouseup", this.handleMouseUp);
+  React.useEffect(() => {
+    const sizeObserver = new ResizeObserver(entries => {
+      entries.forEach(({ target }) => {
+        if (
+          size.width !== target.clientWidth ||
+          size.height !== target.clientHeight
+        ) {
+          setSize({ width: target.clientWidth, height: target.clientHeight });
+        }
+      });
+    });
+    sizeObserver.observe(comRef.current);
+
+    return () => sizeObserver.disconnect();
+  }, [comRef]);
+
+  return size;
+};
+
+function usePosition({ menuWidth, menuHeight, isSelectingText, props }) {
+  const { view, active } = props;
+  const { selection } = view.state;
+
+  if (!active || !menuWidth || !menuHeight || SSR || isSelectingText) {
+    return defaultPosition;
   }
 
-  componentDidUpdate() {
-    const newState = this.calculatePosition(this.props);
+  // based on the start and end of the selection calculate the position at
+  // the center top
+  const fromPos = view.coordsAtPos(selection.$from.pos);
+  const toPos = view.coordsAtPos(selection.$to.pos);
 
-    if (!isEqual(newState, this.state)) {
-      this.setState(newState);
-    }
+  // ensure that start < end
+  const startPos = fromPos.left < toPos.left ? fromPos : toPos;
+  const endPos = fromPos.left < toPos.left ? toPos : fromPos;
+
+  // tables are an oddity, and need their own logic
+  const isColSelection = selection.isColSelection && selection.isColSelection();
+  const isRowSelection = selection.isRowSelection && selection.isRowSelection();
+
+  if (isRowSelection) {
+    endPos.left = startPos.left + 12;
+  } else if (isColSelection) {
+    const { node: element } = view.domAtPos(selection.$from.pos);
+    const { width } = element.getBoundingClientRect();
+    endPos.left = startPos.left + width;
   }
 
-  componentWillUnmount() {
-    window.removeEventListener("mousedown", this.handleMouseDown);
-    window.removeEventListener("mouseup", this.handleMouseUp);
-  }
+  const halfSelection = Math.abs(endPos.left - startPos.left) / 2;
+  const centerOfSelection = startPos.left + halfSelection;
 
-  handleMouseDown = () => {
-    if (!this.props.active) {
-      this.setState(state => ({ ...state, isSelectingText: true }));
-    }
+  // position the menu so that it is centered over the selection except in
+  // the cases where it would extend off the edge of the screen. In these
+  // instances leave a margin
+  const margin = 12;
+  const left = Math.min(
+    window.innerWidth - menuWidth - margin,
+    Math.max(margin, centerOfSelection - menuWidth / 2)
+  );
+  const top = Math.min(
+    window.innerHeight - menuHeight - margin,
+    Math.max(margin, Math.min(startPos.top, fromPos.top) - menuHeight)
+  );
+
+  // if the menu has been offset to not extend offscreen then we should adjust
+  // the position of the triangle underneath to correctly point to the center
+  // of the selection still
+  const offset = left - (centerOfSelection - menuWidth / 2);
+
+  return {
+    left: Math.round(left + window.scrollX),
+    top: Math.round(top + window.scrollY),
+    offset: Math.round(offset),
+    visible: true,
   };
+}
 
-  handleMouseUp = () => {
-    this.setState(state => ({ ...state, isSelectingText: false }));
-  };
+function FloatingToolbar(props) {
+  const menuRef = props.forwardedRef || React.createRef<HTMLDivElement>();
+  const [isSelectingText, setSelectingText] = React.useState(false);
+  const size = useComponentSize(menuRef);
+  const position = usePosition({
+    menuWidth: size.width,
+    menuHeight: size.height,
+    isSelectingText,
+    props,
+  });
 
-  calculatePosition(props) {
-    const { view, active } = props;
-    const { selection } = view.state;
-
-    if (!active || !this.menuRef.current || SSR || this.state.isSelectingText) {
-      return {
-        left: -1000,
-        top: 0,
-        offset: 0,
-        visible: false,
-        isSelectingText: this.state.isSelectingText,
-      };
-    }
-
-    // based on the start and end of the selection calculate the position at
-    // the center top
-    const startPos = view.coordsAtPos(selection.$from.pos);
-    const endPos = view.coordsAtPos(selection.$to.pos);
-
-    // tables are an oddity, and need their own logic
-    const isColSelection =
-      selection.isColSelection && selection.isColSelection();
-    const isRowSelection =
-      selection.isRowSelection && selection.isRowSelection();
-
-    if (isRowSelection) {
-      endPos.left = startPos.left + 12;
-    } else if (isColSelection) {
-      const { node: element } = view.domAtPos(selection.$from.pos);
-      const { width } = element.getBoundingClientRect();
-      endPos.left = startPos.left + width;
-    }
-
-    const halfSelection = Math.abs(endPos.left - startPos.left) / 2;
-    const centerOfSelection = startPos.left + halfSelection;
-
-    // position the menu so that it is centered over the selection except in
-    // the cases where it would extend off the edge of the screen. In these
-    // instances leave a margin
-    const { offsetWidth, offsetHeight } = this.menuRef.current;
-    const margin = 12;
-    const left = Math.min(
-      window.innerWidth - offsetWidth - margin,
-      Math.max(margin, centerOfSelection - offsetWidth / 2)
-    );
-    const top = Math.min(
-      window.innerHeight - offsetHeight - margin,
-      Math.max(margin, startPos.top - offsetHeight)
-    );
-
-    // if the menu has been offset to not extend offscreen then we should adjust
-    // the position of the triangle underneath to correctly point to the center
-    // of the selection still
-    const offset = Math.round(left - (centerOfSelection - offsetWidth / 2));
-
-    return {
-      left: Math.round(left + window.scrollX),
-      top: Math.round(top + window.scrollY),
-      offset,
-      visible: true,
-      isSelectingText: this.state.isSelectingText,
+  React.useEffect(() => {
+    const handleMouseDown = () => {
+      if (!props.active) {
+        setSelectingText(true);
+      }
     };
-  }
 
-  render() {
-    const { children, active } = this.props;
+    const handleMouseUp = () => {
+      setSelectingText(false);
+    };
 
-    // only render children when state is updated to visible
-    // to prevent gaining input focus before calculatePosition runs
-    return (
-      <Portal>
-        <Wrapper
-          active={active && this.state.visible}
-          ref={this.menuRef}
-          offset={this.state.offset}
-          style={{
-            top: `${this.state.top}px`,
-            left: `${this.state.left}px`,
-          }}
-        >
-          {this.state.visible && children}
-        </Wrapper>
-      </Portal>
-    );
-  }
+    window.addEventListener("mousedown", handleMouseDown);
+    window.addEventListener("mouseup", handleMouseUp);
+
+    return () => {
+      window.removeEventListener("mousedown", handleMouseDown);
+      window.removeEventListener("mouseup", handleMouseUp);
+    };
+  }, [props.active]);
+
+  // only render children when state is updated to visible
+  // to prevent gaining input focus before calculatePosition runs
+  return (
+    <Portal>
+      <Wrapper
+        active={props.active && position.visible}
+        ref={menuRef}
+        offset={position.offset}
+        style={{
+          top: `${position.top}px`,
+          left: `${position.left}px`,
+        }}
+      >
+        {position.visible && props.children}
+      </Wrapper>
+    </Portal>
+  );
 }
 
 const Wrapper = styled.div<{
@@ -190,8 +204,9 @@ const Wrapper = styled.div<{
   }
 `;
 
-export default React.forwardRef(
-  (props: Props, ref: React.RefObject<HTMLDivElement>) => (
-    <FloatingToolbar {...props} forwardedRef={ref} />
-  )
-);
+export default React.forwardRef(function FloatingToolbarWithForwardedRef(
+  props: Props,
+  ref: React.RefObject<HTMLDivElement>
+) {
+  return <FloatingToolbar {...props} forwardedRef={ref} />;
+});

--- a/src/components/FloatingToolbar.tsx
+++ b/src/components/FloatingToolbar.tsx
@@ -157,6 +157,7 @@ const Wrapper = styled.div<{
   active?: boolean;
   offset: number;
 }>`
+  will-change: opacity, transform;
   padding: 8px 16px;
   position: absolute;
   z-index: ${props => props.theme.zIndex + 100};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4450,6 +4450,11 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
+resize-observer-polyfill@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"


### PR DESCRIPTION
As I've still never been able to reproduce on demand it's difficult to know if this fixes the issue entirely, but moving the rendering to a more reactive approach based on ResizeObserver and separating the state of the menu size and position seems like it would uncouple everything that could possibly cause a render loop.

This PR also includes a fix for the toolbar being mispositioned when a selection spans multiple lines and the lower lines of content are shorter than lines above.

tentatively closes #208