### PR TITLE
fix: hide image block when no callback is passed in

### DIFF
--- a/src/components/BlockMenu.tsx
+++ b/src/components/BlockMenu.tsx
@@ -344,7 +344,7 @@ class BlockMenu extends React.Component<Props, State> {
   }
 
   get filtered() {
-    const { dictionary, embeds, search = "" } = this.props;
+    const { dictionary, embeds, search = "", uploadImage } = this.props;
     let items: (EmbedDescriptor | MenuItem)[] = getMenuItems(dictionary);
     const embedItems: EmbedDescriptor[] = [];
 
@@ -366,6 +366,9 @@ class BlockMenu extends React.Component<Props, State> {
 
     const filtered = items.filter(item => {
       if (item.name === "separator") return true;
+
+      // If no image upload callback has been passed, filter the image block out
+      if (!uploadImage && item.name === "image") return false;
 
       const n = search.toLowerCase();
       return (
@@ -396,7 +399,7 @@ class BlockMenu extends React.Component<Props, State> {
   }
 
   render() {
-    const { isActive } = this.props;
+    const { isActive, uploadImage } = this.props;
     const items = this.filtered;
     const { insertItem, ...positioning } = this.state;
 
@@ -457,14 +460,16 @@ class BlockMenu extends React.Component<Props, State> {
               )}
             </List>
           )}
-          <VisuallyHidden>
-            <input
-              type="file"
-              ref={this.inputRef}
-              onChange={this.handleImagePicked}
-              accept="image/*"
-            />
-          </VisuallyHidden>
+          {uploadImage && (
+            <VisuallyHidden>
+              <input
+                type="file"
+                ref={this.inputRef}
+                onChange={this.handleImagePicked}
+                accept="image/*"
+              />
+            </VisuallyHidden>
+          )}
         </Wrapper>
       </Portal>
     );

--- a/src/nodes/Image.tsx
+++ b/src/nodes/Image.tsx
@@ -24,7 +24,10 @@ const uploadPlugin = options =>
     props: {
       handleDOMEvents: {
         paste(view, event: ClipboardEvent): boolean {
-          if (view.props.editable && !view.props.editable(view.state)) {
+          if (
+            (view.props.editable && !view.props.editable(view.state)) ||
+            !options.uploadImage
+          ) {
             return false;
           }
 
@@ -48,7 +51,10 @@ const uploadPlugin = options =>
           return true;
         },
         drop(view, event: DragEvent): boolean {
-          if (view.props.editable && !view.props.editable(view.state)) {
+          if (
+            (view.props.editable && !view.props.editable(view.state)) ||
+            !options.uploadImage
+          ) {
             return false;
           }
 


### PR DESCRIPTION
I see there is a console warning when no image upload handler is passed in, but (at least for my use case), it would be better to hide the image block when no callback is provided so the feature can be optional.