### PR TITLE
fix: allow functional component types

### DIFF
--- a/src/components/BlockMenuItem.tsx
+++ b/src/components/BlockMenuItem.tsx
@@ -8,7 +8,7 @@ type Props = {
   disabled?: boolean;
   onClick: () => void;
   theme: typeof theme;
-  icon: typeof React.Component;
+  icon: typeof React.Component | React.FC<any>;
   title: string;
   shortcut?: string;
 };

--- a/src/components/LinkEditor.tsx
+++ b/src/components/LinkEditor.tsx
@@ -27,7 +27,7 @@ type Props = {
   mark?: Mark;
   from: number;
   to: number;
-  tooltip: typeof React.Component;
+  tooltip: typeof React.Component | React.FC<any>;
   dictionary: typeof baseDictionary;
   onRemoveLink?: () => void;
   onCreateLink?: (title: string) => Promise<void>;

--- a/src/components/LinkToolbar.tsx
+++ b/src/components/LinkToolbar.tsx
@@ -9,7 +9,7 @@ import baseDictionary from "../dictionary";
 type Props = {
   isActive: boolean;
   view: EditorView;
-  tooltip: typeof React.Component;
+  tooltip: typeof React.Component | React.FC<any>;
   dictionary: typeof baseDictionary;
   onCreateLink?: (title: string) => Promise<string>;
   onSearchLink?: (term: string) => Promise<SearchResult[]>;

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -7,7 +7,7 @@ import theme from "../theme";
 import { MenuItem } from "../types";
 
 type Props = {
-  tooltip: typeof React.Component;
+  tooltip: typeof React.Component | React.FC<any>;
   commands: Record<string, any>;
   view: EditorView;
   theme: typeof theme;

--- a/src/components/SelectionToolbar.tsx
+++ b/src/components/SelectionToolbar.tsx
@@ -20,7 +20,7 @@ import baseDictionary from "../dictionary";
 
 type Props = {
   dictionary: typeof baseDictionary;
-  tooltip: typeof React.Component;
+  tooltip: typeof React.Component | React.FC<any>;
   isTemplate: boolean;
   commands: Record<string, any>;
   onSearchLink?: (term: string) => Promise<SearchResult[]>;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -106,8 +106,8 @@ export type Props = {
   onClickHashtag?: (tag: string) => void;
   onKeyDown?: (event: React.KeyboardEvent<HTMLDivElement>) => void;
   embeds: EmbedDescriptor[];
-  onShowToast?: (message: string) => void;
-  tooltip: typeof React.Component;
+  onShowToast?: (message: string, code: string) => void;
+  tooltip: typeof React.Component | React.FC<any>;
   className?: string;
   style?: Record<string, string>;
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,7 +2,7 @@ import * as React from "react";
 import { EditorState } from "prosemirror-state";
 
 export type MenuItem = {
-  icon?: typeof React.Component;
+  icon?: typeof React.Component | React.FC<any>;
   name?: string;
   title?: string;
   shortcut?: string;
@@ -15,5 +15,5 @@ export type MenuItem = {
 
 export type EmbedDescriptor = MenuItem & {
   matcher: (url: string) => boolean | [];
-  component: typeof React.Component;
+  component: typeof React.Component | React.FC<any>;
 };


### PR DESCRIPTION
TypeScript was complaining about me passing functional components `React.FC<Props>` as the icon for embeds or for tooltips. This change fixed the problem for me locally. I also noticed the second argument of `onShowToast` (the stable string/message code) wasn't included in the type definition and added it.