### PR TITLE
feat: add toast type for easier use in TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,12 +191,11 @@ The editor provides an ability to create links from the formatting toolbar for o
 />
 ```
 
-#### `onShowToast(message: string, id: ToastId): void`
+#### `onShowToast(message: string, type: ToastType): void`
 
-Triggered when the editor wishes to show an error message to the user. Hook into your apps
+Triggered when the editor wishes to show a message to the user. Hook into your app's
 notification system, or simplisticly use `window.alert(message)`. The second parameter
-is a stable identifier you can use to identify the message if you'd prefer to write
-your own copy.
+is the type of toast: 'error' or 'info'.
 
 
 #### `onClickLink(href: string): void`

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ The editor provides an ability to create links from the formatting toolbar for o
 />
 ```
 
-#### `onShowToast(message: string, id: string): void`
+#### `onShowToast(message: string, id: ToastId): void`
 
 Triggered when the editor wishes to show an error message to the user. Hook into your apps
 notification system, or simplisticly use `window.alert(message)`. The second parameter

--- a/src/commands/createAndInsertLink.ts
+++ b/src/commands/createAndInsertLink.ts
@@ -1,5 +1,6 @@
 import { EditorView } from "prosemirror-view";
 import baseDictionary from "../dictionary";
+import { ToastType } from "../types";
 
 function findPlaceholderLink(doc, href) {
   let result;
@@ -77,7 +78,7 @@ const createAndInsertLink = async function(
 
     // let the user know
     if (onShowToast) {
-      onShowToast(options.dictionary.createLinkError, "link_create_error");
+      onShowToast(options.dictionary.createLinkError, ToastType.Error);
     }
   }
 };

--- a/src/commands/insertFiles.ts
+++ b/src/commands/insertFiles.ts
@@ -1,6 +1,7 @@
 import uploadPlaceholderPlugin, {
   findPlaceholder,
 } from "../lib/uploadPlaceholder";
+import { ToastType } from "../types";
 
 const insertFiles = function(view, event, pos, files, options) {
   // filter to only include image files
@@ -77,7 +78,7 @@ const insertFiles = function(view, event, pos, files, options) {
 
         // let the user know
         if (onShowToast) {
-          onShowToast(dictionary.imageUploadError, "image_upload_error");
+          onShowToast(dictionary.imageUploadError, ToastType.Error);
         }
       })
       // eslint-disable-next-line no-loop-func

--- a/src/components/BlockMenu.tsx
+++ b/src/components/BlockMenu.tsx
@@ -4,7 +4,7 @@ import { Portal } from "react-portal";
 import { EditorView } from "prosemirror-view";
 import { findParentNode } from "prosemirror-utils";
 import styled from "styled-components";
-import { EmbedDescriptor, MenuItem } from "../types";
+import { EmbedDescriptor, MenuItem, ToastType } from "../types";
 import BlockMenuItem from "./BlockMenuItem";
 import Input from "./Input";
 import VisuallyHidden from "./VisuallyHidden";
@@ -186,7 +186,7 @@ class BlockMenu extends React.Component<Props, State> {
       if (!matches && this.props.onShowToast) {
         this.props.onShowToast(
           this.props.dictionary.embedInvalidLink,
-          "embed_invalid_link"
+          ToastType.Error
         );
         return;
       }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,7 +16,7 @@ import { light as lightTheme, dark as darkTheme } from "./theme";
 import baseDictionary from "./dictionary";
 import Flex from "./components/Flex";
 import { SearchResult } from "./components/LinkEditor";
-import { EmbedDescriptor, ToastId } from "./types";
+import { EmbedDescriptor, ToastType } from "./types";
 import SelectionToolbar from "./components/SelectionToolbar";
 import BlockMenu from "./components/BlockMenu";
 import LinkToolbar from "./components/LinkToolbar";
@@ -106,7 +106,7 @@ export type Props = {
   onClickHashtag?: (tag: string) => void;
   onKeyDown?: (event: React.KeyboardEvent<HTMLDivElement>) => void;
   embeds: EmbedDescriptor[];
-  onShowToast?: (message: string, code: ToastId) => void;
+  onShowToast?: (message: string, code: ToastType) => void;
   tooltip: typeof React.Component | React.FC<any>;
   className?: string;
   style?: Record<string, string>;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,7 +16,7 @@ import { light as lightTheme, dark as darkTheme } from "./theme";
 import baseDictionary from "./dictionary";
 import Flex from "./components/Flex";
 import { SearchResult } from "./components/LinkEditor";
-import { EmbedDescriptor } from "./types";
+import { EmbedDescriptor, ToastId } from "./types";
 import SelectionToolbar from "./components/SelectionToolbar";
 import BlockMenu from "./components/BlockMenu";
 import LinkToolbar from "./components/LinkToolbar";
@@ -106,7 +106,7 @@ export type Props = {
   onClickHashtag?: (tag: string) => void;
   onKeyDown?: (event: React.KeyboardEvent<HTMLDivElement>) => void;
   embeds: EmbedDescriptor[];
-  onShowToast?: (message: string, code: string) => void;
+  onShowToast?: (message: string, code: ToastId) => void;
   tooltip: typeof React.Component | React.FC<any>;
   className?: string;
   style?: Record<string, string>;

--- a/src/nodes/CodeFence.ts
+++ b/src/nodes/CodeFence.ts
@@ -18,6 +18,7 @@ import { textblockTypeInputRule } from "prosemirror-inputrules";
 import copy from "copy-to-clipboard";
 import Prism, { LANGUAGES } from "../plugins/Prism";
 import Node from "./Node";
+import { ToastType } from "../types";
 
 [
   bash,
@@ -102,7 +103,7 @@ export default class CodeFence extends Node {
       if (this.options.onShowToast) {
         this.options.onShowToast(
           this.options.dictionary.codeCopied,
-          "code_copied"
+          ToastType.Info
         );
       }
     };

--- a/src/nodes/Heading.ts
+++ b/src/nodes/Heading.ts
@@ -9,6 +9,7 @@ import backspaceToParagraph from "../commands/backspaceToParagraph";
 import toggleBlockType from "../commands/toggleBlockType";
 import headingToSlug from "../lib/headingToSlug";
 import Node from "./Node";
+import { ToastType } from "../types";
 
 export default class Heading extends Node {
   get name() {
@@ -87,7 +88,7 @@ export default class Heading extends Node {
       if (this.options.onShowToast) {
         this.options.onShowToast(
           this.options.dictionary.linkCopied,
-          "heading_copied"
+          ToastType.Info
         );
       }
     };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,12 +1,10 @@
 import * as React from "react";
 import { EditorState } from "prosemirror-state";
 
-export type ToastId =
-  | "code_copied"
-  | "embed_invalid_link"
-  | "heading_copied"
-  | "image_upload_error"
-  | "link_create_error";
+export enum ToastType {
+  Error = "error",
+  Info = "info",
+}
 
 export type MenuItem = {
   icon?: typeof React.Component | React.FC<any>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,13 @@
 import * as React from "react";
 import { EditorState } from "prosemirror-state";
 
+export type ToastId =
+  | "code_copied"
+  | "embed_invalid_link"
+  | "heading_copied"
+  | "image_upload_error"
+  | "link_create_error";
+
 export type MenuItem = {
   icon?: typeof React.Component | React.FC<any>;
   name?: string;


### PR DESCRIPTION
This adds a type for toast ids to make it more obvious to consumers (via autocomplete/intellisense) which values can be received in `onShowToast()`.