### PR TITLE
fix: use suggestedLinkTitle when creating new docs

### DIFF
--- a/src/components/LinkEditor.tsx
+++ b/src/components/LinkEditor.tsx
@@ -65,7 +65,7 @@ class LinkEditor extends React.Component<Props, State> {
     return this.props.mark ? this.props.mark.attrs.href : "";
   }
 
-  get suggestedDocTitle(): string {
+  get suggestedLinkTitle(): string {
     const { state } = this.props.view;
     const { value } = this.state;
     const selectionText = state.doc.cut(
@@ -125,7 +125,7 @@ class LinkEditor extends React.Component<Props, State> {
           if (result) {
             this.save(result.url, result.title);
           } else if (onCreateLink && selectedIndex === results.length) {
-            this.handleCreateLink(this.suggestedDocTitle);
+            this.handleCreateLink(this.suggestedLinkTitle);
           }
         } else {
           // saves the raw input as href
@@ -257,14 +257,16 @@ class LinkEditor extends React.Component<Props, State> {
     const Tooltip = this.props.tooltip;
     const looksLikeUrl = value.match(/^https?:\/\//i);
 
+    const suggestedLinkTitle = this.suggestedLinkTitle;
+
     const showCreateLink =
       !!this.props.onCreateLink &&
-      !(this.suggestedDocTitle === this.initialValue) &&
-      this.suggestedDocTitle.length > 0 &&
+      !(suggestedLinkTitle === this.initialValue) &&
+      suggestedLinkTitle.length > 0 &&
       !looksLikeUrl;
 
     const showResults =
-      !!this.suggestedDocTitle && (showCreateLink || results.length > 0);
+      !!suggestedLinkTitle && (showCreateLink || results.length > 0);
 
     return (
       <Wrapper>
@@ -311,11 +313,11 @@ class LinkEditor extends React.Component<Props, State> {
             {showCreateLink && (
               <LinkSearchResult
                 key="create"
-                title={dictionary.createNewDoc(this.suggestedDocTitle)}
+                title={dictionary.createNewDoc(suggestedLinkTitle)}
                 icon={<PlusIcon color={theme.toolbarItem} />}
                 onMouseOver={() => this.handleFocusLink(results.length)}
                 onClick={() => {
-                  this.handleCreateLink(this.suggestedDocTitle);
+                  this.handleCreateLink(suggestedLinkTitle);
 
                   if (this.initialSelectionLength) {
                     this.moveSelectionToEnd();

--- a/src/components/LinkEditor.tsx
+++ b/src/components/LinkEditor.tsx
@@ -65,6 +65,17 @@ class LinkEditor extends React.Component<Props, State> {
     return this.props.mark ? this.props.mark.attrs.href : "";
   }
 
+  get suggestedDocTitle(): string {
+    const { state } = this.props.view;
+    const { value } = this.state;
+    const selectionText = state.doc.cut(
+      state.selection.from,
+      state.selection.to
+    ).textContent;
+
+    return value.trim() || selectionText.trim();
+  }
+
   componentWillUnmount = () => {
     // If we discarded the changes then nothing to do
     if (this.discardInputValue) {
@@ -114,7 +125,7 @@ class LinkEditor extends React.Component<Props, State> {
           if (result) {
             this.save(result.url, result.title);
           } else if (onCreateLink && selectedIndex === results.length) {
-            this.handleCreateLink(value);
+            this.handleCreateLink(this.suggestedDocTitle);
           }
         } else {
           // saves the raw input as href
@@ -240,28 +251,20 @@ class LinkEditor extends React.Component<Props, State> {
   };
 
   render() {
-    const { dictionary, theme, view } = this.props;
+    const { dictionary, theme } = this.props;
     const { value, results, selectedIndex } = this.state;
 
     const Tooltip = this.props.tooltip;
     const looksLikeUrl = value.match(/^https?:\/\//i);
 
-    const { state } = view;
-    const selectionText = state.doc.cut(
-      state.selection.from,
-      state.selection.to
-    ).textContent;
-
-    const suggestedDocTitle = value.trim() || selectionText.trim();
-
     const showCreateLink =
       !!this.props.onCreateLink &&
-      !(suggestedDocTitle === this.initialValue) &&
-      suggestedDocTitle.length > 0 &&
+      !(this.suggestedDocTitle === this.initialValue) &&
+      this.suggestedDocTitle.length > 0 &&
       !looksLikeUrl;
 
     const showResults =
-      !!suggestedDocTitle && (showCreateLink || results.length > 0);
+      !!this.suggestedDocTitle && (showCreateLink || results.length > 0);
 
     return (
       <Wrapper>
@@ -308,11 +311,11 @@ class LinkEditor extends React.Component<Props, State> {
             {showCreateLink && (
               <LinkSearchResult
                 key="create"
-                title={dictionary.createNewDoc(suggestedDocTitle)}
+                title={dictionary.createNewDoc(this.suggestedDocTitle)}
                 icon={<PlusIcon color={theme.toolbarItem} />}
                 onMouseOver={() => this.handleFocusLink(results.length)}
                 onClick={() => {
-                  this.handleCreateLink(suggestedDocTitle);
+                  this.handleCreateLink(this.suggestedDocTitle);
 
                   if (this.initialSelectionLength) {
                     this.moveSelectionToEnd();


### PR DESCRIPTION
Using the keyboard to create a link didn't take into account the selection suggestion