### PR TITLE
fix: Add class to floating toolbar

### DIFF
--- a/src/components/FloatingToolbar.tsx
+++ b/src/components/FloatingToolbar.tsx
@@ -144,6 +144,7 @@ function FloatingToolbar(props) {
   return (
     <Portal>
       <Wrapper
+        className="floating-toolbar"
         active={props.active && position.visible}
         ref={menuRef}
         offset={position.offset}


### PR DESCRIPTION
The toolbar has the potential of floating beneath things, for one example.  This allows for targeting the toolbar since there's no other way to do this it seems.