### PR TITLE
fix: lodash imports to use tree shaking to reduce bundle size

### DIFF
--- a/example/src/index.js
+++ b/example/src/index.js
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { debounce } from "lodash";
+import debounce from "lodash/debounce";
 import ReactDOM from "react-dom";
 import Editor from "../../src";
 

--- a/src/components/BlockMenu.tsx
+++ b/src/components/BlockMenu.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { capitalize } from "lodash";
+import capitalize from "lodash/capitalize";
 import { Portal } from "react-portal";
 import { EditorView } from "prosemirror-view";
 import { findParentNode } from "prosemirror-utils";

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
 /* global window File Promise */
 import * as React from "react";
-import { memoize } from "lodash";
+import memoize from "lodash/memoize";
 import { EditorState, Selection, Plugin } from "prosemirror-state";
 import { dropCursor } from "prosemirror-dropcursor";
 import { gapCursor } from "prosemirror-gapcursor";

--- a/src/lib/headingToSlug.ts
+++ b/src/lib/headingToSlug.ts
@@ -1,5 +1,5 @@
 import { Node } from "prosemirror-model";
-import { escape } from "lodash";
+import escape from "lodash/escape";
 import slugify from "slugify";
 
 // Slugify, escape, and remove periods from headings so that they are

--- a/src/plugins/Prism.ts
+++ b/src/plugins/Prism.ts
@@ -1,5 +1,5 @@
 import refractor from "refractor/core";
-import { flattenDeep } from "lodash";
+import flattenDeep from "lodash/flattenDeep";
 import { Plugin, PluginKey } from "prosemirror-state";
 import { Decoration, DecorationSet } from "prosemirror-view";
 import { findBlockNodes } from "prosemirror-utils";


### PR DESCRIPTION
I've been trying to reduce our bundle size and I saw that rich-markdown-editor is importing the entirety of lodash, which is a big library. These changes should help reduce the size.