### PR TITLE
fix: \n in paragraph converted to newline on reload

### DIFF
--- a/src/lib/markdown/serializer.js
+++ b/src/lib/markdown/serializer.js
@@ -356,10 +356,13 @@ export class MarkdownSerializerState {
   // has special meaning only at the start of the line.
   esc(str, startOfLine) {
     str = str.replace(/[`*\\~\[\]]/g, "\\$&");
-    if (startOfLine)
+    if (startOfLine) {
       str = str.replace(/^[:#\-*+]/, "\\$&").replace(/^(\d+)\./, "$1\\.");
+    }
 
-    if (this.inTable) str = str.replace(/\|/gi, "\\$&");
+    if (this.inTable) {
+      str = str.replace(/\|/gi, "\\$&");
+    }
 
     return str;
   }

--- a/src/lib/markdown/tables.ts
+++ b/src/lib/markdown/tables.ts
@@ -1,6 +1,8 @@
 import MarkdownIt from "markdown-it";
 import Token from "markdown-it/lib/token";
 
+const BREAK_REGEX = /(?:^|[^\\])\\n/;
+
 export default function markdownTables(md: MarkdownIt) {
   // insert a new rule after the "inline" rules are parsed
   md.core.ruler.after("inline", "tables-pm", state => {
@@ -13,13 +15,14 @@ export default function markdownTables(md: MarkdownIt) {
       }
 
       // convert break line into br tag
-      if (tokens[i].type === "inline" && tokens[i].content.includes("\\n")) {
+      if (tokens[i].type === "inline" && tokens[i].content.match(BREAK_REGEX)) {
         const existing = tokens[i].children || [];
         tokens[i].children = [];
 
         existing.forEach(child => {
-          if (child.content.includes("\\n")) {
-            const breakParts = child.content.split("\\n");
+          const breakParts = child.content.split(BREAK_REGEX);
+
+          if (breakParts.length > 1) {
             breakParts.forEach((part, index) => {
               const token = new Token("text", "", 1);
               token.content = part.trim();

--- a/src/lib/markdown/tables.ts
+++ b/src/lib/markdown/tables.ts
@@ -22,7 +22,9 @@ export default function markdownTables(md: MarkdownIt) {
         existing.forEach(child => {
           const breakParts = child.content.split(BREAK_REGEX);
 
-          if (breakParts.length > 1) {
+          // a schema agnostic way to know if a node is inline code would be
+          // great, got now we're stuck checking the node type.
+          if (breakParts.length > 1 && child.type !== "code_inline") {
             breakParts.forEach((part, index) => {
               const token = new Token("text", "", 1);
               token.content = part.trim();

--- a/src/lib/markdown/tables.ts
+++ b/src/lib/markdown/tables.ts
@@ -14,7 +14,7 @@ export default function markdownTables(md: MarkdownIt) {
         tokens[i].level--;
       }
 
-      // convert break line into br tag
+      // convert unescaped \n in the text into real br tag
       if (tokens[i].type === "inline" && tokens[i].content.match(BREAK_REGEX)) {
         const existing = tokens[i].children || [];
         tokens[i].children = [];
@@ -23,7 +23,7 @@ export default function markdownTables(md: MarkdownIt) {
           const breakParts = child.content.split(BREAK_REGEX);
 
           // a schema agnostic way to know if a node is inline code would be
-          // great, got now we're stuck checking the node type.
+          // great, for now we are stuck checking the node type.
           if (breakParts.length > 1 && child.type !== "code_inline") {
             breakParts.forEach((part, index) => {
               const token = new Token("text", "", 1);


### PR DESCRIPTION
The logic should take into account whether the backslash is escaped, except in inline code blocks where it should be skipped altogether.

Related https://github.com/outline/outline/issues/1561