### PR TITLE
fix: Cursor does not move predictably around headings in Firefox

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -745,6 +745,20 @@ const StyledEditor = styled("div")<{
       font-size: 13px;
       left: -24px;
     }
+
+    &:hover {
+      .heading-anchor {
+        opacity: 1;
+      }
+    }
+  }
+
+  .heading-name {
+    color: ${props => props.theme.text};
+
+    &:hover {
+      text-decoration: none;
+    }
   }
 
   a:first-child {
@@ -779,18 +793,6 @@ const StyledEditor = styled("div")<{
   }
   h6:not(.placeholder):before {
     content: "H6";
-  }
-
-  .heading-name {
-    color: ${props => props.theme.text};
-
-    &:hover {
-      text-decoration: none;
-
-      .heading-anchor {
-        opacity: 1;
-      }
-    }
   }
 
   .with-emoji {

--- a/src/nodes/Heading.ts
+++ b/src/nodes/Heading.ts
@@ -78,7 +78,8 @@ export default class Heading extends Node {
     return event => {
       // this is unfortunate but appears to be the best way to grab the anchor
       // as it's added directly to the dom by a decoration.
-      const hash = `#${event.target.parentElement.parentElement.id}`;
+      const anchor = event.target.nextSibling.getElementsByTagName("a")[0];
+      const hash = `#${anchor.id}`;
 
       // the existing url might contain a hash already, lets make sure to remove
       // that rather than appending another one.
@@ -141,7 +142,7 @@ export default class Heading extends Node {
                   : 1;
 
               decorations.push(
-                Decoration.node(pos, pos + node.nodeSize, {
+                Decoration.inline(pos, pos + node.nodeSize, {
                   id,
                   class: "heading-name",
                   nodeName: "a",


### PR DESCRIPTION
Honestly, it's unclear why this affects they keyboard behavior in Firefox only – but having an anchor tag that wraps around a button is not best practice anyway so that + contenteditable is the culprit.

closes https://github.com/outline/outline/issues/1565