### PR TITLE
fix: Pasting into code formatting should not leave the code block

### DIFF
--- a/src/plugins/MarkdownPaste.ts
+++ b/src/plugins/MarkdownPaste.ts
@@ -2,6 +2,7 @@ import { Plugin } from "prosemirror-state";
 import { toggleMark } from "prosemirror-commands";
 import Extension from "../lib/Extension";
 import isUrl from "../lib/isUrl";
+import isInCode from "../queries/isInCode";
 
 export default class MarkdownPaste extends Extension {
   get name() {
@@ -68,6 +69,11 @@ export default class MarkdownPaste extends Extension {
             if (text.length === 0 || html) return false;
 
             event.preventDefault();
+
+            if (isInCode(view.state)) {
+              view.dispatch(view.state.tr.insertText(text));
+              return true;
+            }
 
             const paste = this.editor.parser.parse(text);
             const slice = paste.slice(0);

--- a/src/queries/isInCode.ts
+++ b/src/queries/isInCode.ts
@@ -1,0 +1,12 @@
+import isMarkActive from "./isMarkActive";
+
+export default function isInCode(state) {
+  const $head = state.selection.$head;
+  for (let d = $head.depth; d > 0; d--) {
+    if ($head.node(d).type === state.schema.nodes.code_block) {
+      return true;
+    }
+  }
+
+  return isMarkActive(state.schema.marks.code_inline)(state);
+}


### PR DESCRIPTION
Pasting in a code block should not attempt to parse as Markdown.

closes https://github.com/outline/outline/issues/1566