### PR TITLE
fix: Cannot use multiple underscore characters within inline code mark

### DIFF
--- a/src/lib/markInputRule.ts
+++ b/src/lib/markInputRule.ts
@@ -39,12 +39,12 @@ export default function(
         const textStart = matchStart + match[m - 1].lastIndexOf(match[m]);
         const textEnd = textStart + match[m].length;
 
-        const excludedMarks = getMarksBetween(start, end, state).filter(
-          item => item.end > matchStart
-        );
+        const excludedMarks = getMarksBetween(start, end, state)
+          .filter(item => item.mark.type.excludes(markType))
+          .filter(item => item.end > matchStart);
 
         if (excludedMarks.length) {
-          return tr;
+          return null;
         }
 
         if (textEnd < matchEnd) {

--- a/src/marks/Code.ts
+++ b/src/marks/Code.ts
@@ -30,7 +30,7 @@ export default class Code extends Mark {
 
   get schema() {
     return {
-      excludes: "strong em link mark strikethrough",
+      excludes: "_",
       parseDOM: [{ tag: "code" }],
       toDOM: () => ["code", { spellCheck: false }],
     };


### PR DESCRIPTION
Due to the inline markdown nature of the editor we can't stop underlines from parsing entirely, but they can and should be ignored within an inline code mark.

closes #296 