### PR TITLE
fix: toolbar gets influenced by external styling

### DIFF
--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -21,7 +21,7 @@ class Menu extends React.Component<Props> {
     const Tooltip = this.props.tooltip;
 
     return (
-      <div>
+      <div style={{ display: 'flex' }}>
         {items.map((item, index) => {
           if (item.name === "separator" && item.visible !== false) {
             return <ToolbarSeparator key={index} />;


### PR DESCRIPTION
The external styling ends up influencing the styling of the toolbar which ends up showing buttons out of position,

<img width="416" alt="Screen Shot 2020-10-06 at 10 54 21 AM" src="https://user-images.githubusercontent.com/64810/95243228-2ecbec00-07c5-11eb-9af0-997f183c965e.png">

This fix neutralizes that and makes sure that buttons are not showing out of position regardless of external styling

<img width="416" alt="Screen Shot 2020-10-06 at 10 54 44 AM" src="https://user-images.githubusercontent.com/64810/95243286-45724300-07c5-11eb-8ac6-a6f9e8640965.png">
