### PR TITLE
fix: change scrollable overflow-x from scroll to auto

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1269,7 +1269,7 @@ const StyledEditor = styled("div")<{
 
   .scrollable {
     overflow-y: hidden;
-    overflow-x: scroll;
+    overflow-x: auto;
     padding-left: 1em;
     margin-left: -1em;
     border-left: 1px solid transparent;


### PR DESCRIPTION
This PR fixes the issue where the horizontal scrollbar is always visible for tables.  

This caused, **especially in dark mode**, a visually distracting experience.

I hope the following screenshots can show the problem:

Before:
<img width="886" alt="CleanShot 2020-11-08 at 17 48 33@2x" src="https://user-images.githubusercontent.com/2592996/98471142-a6d56980-21ea-11eb-8f78-f9b22379a4bf.png">

After:
<img width="886" alt="CleanShot 2020-11-08 at 17 49 04@2x" src="https://user-images.githubusercontent.com/2592996/98471154-b3f25880-21ea-11eb-9109-50e40ed36b29.png">


