### PR TITLE
feat: add a custom scrollbar theme for the scrollable wrapper

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1269,7 +1269,7 @@ const StyledEditor = styled("div")<{
     scrollbar-color: transparent transparent;
 
     &:hover {
-        scrollbar-color: ${props => props.theme.tableDivider} ${props => props.theme.codeBackground};
+        scrollbar-color: ${props => props.theme.scrollbarThumb} ${props => props.theme.scrollbarBackground};
     }
 
     & ::-webkit-scrollbar {
@@ -1278,7 +1278,7 @@ const StyledEditor = styled("div")<{
     }
 
     &:hover ::-webkit-scrollbar {
-        background-color: ${props => props.theme.codeBackground};
+        background-color: ${props => props.theme.scrollbarBackground};
     }
 
     & ::-webkit-scrollbar-thumb {
@@ -1288,8 +1288,8 @@ const StyledEditor = styled("div")<{
     }
 
     &:hover ::-webkit-scrollbar-thumb {
-        background-color: ${props => props.theme.tableDivider};
-        border-color: ${props => props.theme.codeBackground};
+        background-color: ${props => props.theme.scrollbarThumb};
+        border-color: ${props => props.theme.scrollbarBackground};
     }
   }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1269,7 +1269,7 @@ const StyledEditor = styled("div")<{
 
   .scrollable {
     overflow-y: hidden;
-    overflow-x: scroll;
+    overflow-x: auto;
     padding-left: 1em;
     margin-left: -1em;
     border-left: 1px solid transparent;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1266,16 +1266,30 @@ const StyledEditor = styled("div")<{
     position: relative;
     margin: 0.5em 0px;
     scrollbar-width: thin;
+    scrollbar-color: transparent transparent;
+
+    &:hover {
+        scrollbar-color: ${props => props.theme.tableDivider} ${props => props.theme.codeBackground};
+    }
 
     & ::-webkit-scrollbar {
         height: 14px;
+        background-color: transparent;
+    }
+
+    &:hover ::-webkit-scrollbar {
         background-color: ${props => props.theme.codeBackground};
     }
 
     & ::-webkit-scrollbar-thumb {
-        background-color: ${props => props.theme.tableDivider};
-        border: 3px solid ${props => props.theme.codeBackground};
+        background-color: transparent;
+        border: 3px solid transparent;
         border-radius: 7px;
+    }
+
+    &:hover ::-webkit-scrollbar-thumb {
+        background-color: ${props => props.theme.tableDivider};
+        border-color: ${props => props.theme.codeBackground};
     }
   }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1265,6 +1265,18 @@ const StyledEditor = styled("div")<{
   .scrollable-wrapper {
     position: relative;
     margin: 0.5em 0px;
+    scrollbar-width: thin;
+
+    & ::-webkit-scrollbar {
+        height: 14px;
+        background-color: ${props => props.theme.codeBackground};
+    }
+
+    & ::-webkit-scrollbar-thumb {
+        background-color: ${props => props.theme.tableDivider};
+        border: 3px solid ${props => props.theme.codeBackground};
+        border-radius: 7px;
+    }
   }
 
   .scrollable {

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -81,6 +81,9 @@ export const light = {
   codeBorder: colors.grey,
   horizontalRule: colors.greyMid,
   imageErrorBackground: colors.greyLight,
+
+  scrollbarBackground: colors.greyLight,
+  scrollbarThumb: colors.greyMid,
 };
 
 export const dark = {
@@ -107,6 +110,9 @@ export const dark = {
   codeString: "#3d8fd1",
   horizontalRule: colors.lightBlack,
   imageErrorBackground: "rgba(0, 0, 0, 0.5)",
+
+  scrollbarBackground: colors.black,
+  scrollbarThumb: colors.lightBlack,
 };
 
 export default light;


### PR DESCRIPTION
This PR improves upon PR #319 

Native Scrollbars are at least on macOS "light-themed" even when the system is in dark mode.
To make the editor look more consistent in dark mode, I added custom scrollbar CSS, which turns the scrollbar for the `.scrollable` wrapper dark.

Please note: this works only for webkit based browsers.

Please view to following screenshots:

Before:
<img width="886" alt="CleanShot 2020-11-08 at 17 57 56@2x" src="https://user-images.githubusercontent.com/2592996/98471353-f0728400-21eb-11eb-81d1-e5f04aadd4fe.png">

After:
<img width="886" alt="CleanShot 2020-11-08 at 17 57 34@2x" src="https://user-images.githubusercontent.com/2592996/98471348-e5b7ef00-21eb-11eb-9b64-002944cd27bc.png">
