### PR TITLE
fix: add spacer to fix caret on header

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -749,17 +749,6 @@ const StyledEditor = styled("div")<{
     margin: 1em 0 0.5em;
     font-weight: 500;
     cursor: default;
-
-    &:not(.placeholder):before {
-      display: ${props => (props.readOnly ? "none" : "inline")};
-      position: relative;
-      font-family: ${props => props.theme.fontFamilyMono};
-      color: ${props => props.theme.textSecondary};
-      font-size: 13px;
-      margin-right: -16px;
-      left: -20px;
-    }
-
     &:hover {
       .heading-anchor {
         opacity: 1;
@@ -769,7 +758,6 @@ const StyledEditor = styled("div")<{
 
   .heading-name {
     color: ${props => props.theme.text};
-
     &:hover {
       text-decoration: none;
     }
@@ -786,27 +774,45 @@ const StyledEditor = styled("div")<{
     }
   }
 
-  h1:not(.placeholder):before {
-    content: "H1";
-  }
-  h2:not(.placeholder):before {
-    content: "H2";
-  }
-  h3:not(.placeholder):before {
-    content: "H3";
-  }
-  h4:not(.placeholder):before {
-    content: "H4";
-  }
-  h5:not(.placeholder):before {
-    content: "H5";
-  }
-  h6:not(.placeholder):before {
-    content: "H6";
-  }
-
   .with-emoji {
     margin-left: -1em;
+  }
+
+  .heading-spacer {
+    display: inline;
+    &:before {
+      display: ${props => (props.readOnly ? "none" : "inline")};
+      color: ${props => props.theme.textSecondary};
+      position: relative;
+      margin-right: -1.5em;
+      font-family: ${props => props.theme.fontFamilyMono};
+      font-size: 13px;
+      left: -1.7em;
+    }
+  }
+
+  h1:not(.placeholder) .heading-spacer:before {
+    content: "H1";
+  }
+
+  h2:not(.placeholder) .heading-spacer:before {
+    content: "H2";
+  }
+
+  h3:not(.placeholder) .heading-spacer:before {
+    content: "H3";
+  }
+
+  h4:not(.placeholder) .heading-spacer:before {
+    content: "H4";
+  }
+
+  h5:not(.placeholder) .heading-spacer:before {
+    content: "H5";
+  }
+
+  h6:not(.placeholder) .heading-spacer:before {
+    content: "H6";
   }
 
   .heading-anchor {

--- a/src/nodes/Heading.ts
+++ b/src/nodes/Heading.ts
@@ -47,8 +47,15 @@ export default class Heading extends Node {
         button.className = "heading-anchor";
         button.addEventListener("click", this.handleCopyLink());
 
+        // A spacer is added to fix caret sizing challenges
+        const spacer = document.createElement("div");
+        spacer.innerText = ` `;
+        spacer.className = "heading-spacer";
+        spacer.contentEditable="false";
+
         return [
           `h${node.attrs.level + (this.options.offset || 0)}`,
+          spacer,
           button,
           ["span", 0],
         ];

--- a/src/nodes/Heading.ts
+++ b/src/nodes/Heading.ts
@@ -51,7 +51,7 @@ export default class Heading extends Node {
         const spacer = document.createElement("div");
         spacer.innerText = ` `;
         spacer.className = "heading-spacer";
-        spacer.contentEditable="false";
+        spacer.contentEditable = "false";
 
         return [
           `h${node.attrs.level + (this.options.offset || 0)}`,


### PR DESCRIPTION
I think the only fix I found that works is to add a spacer div (not span as the header content specifically looks for a span) so that it is at the same font size as the header text, and allow you to style it's `before` to be the small label.

Not sure if it's a hack or clever - I'll let you decide @tommoor :D