### PR TITLE
Remove left align option from images

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -941,8 +941,7 @@ const StyledEditor = styled("div")<{
   ul,
   ol {
     margin: 0 0.1em;
-    padding: 0 0 0 1.2em;
-    overflow: hidden;
+    padding: 0 0 0 1em;
 
     ul,
     ol {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -701,13 +701,6 @@ const StyledEditor = styled("div")<{
     margin-bottom: 1em;
   }
 
-  .image-left-50 {
-    float: left;
-    width: 50%;
-    margin-right: 2em;
-    margin-bottom: 1em;
-  }
-
   .ProseMirror-hideselection *::selection {
     background: transparent;
   }
@@ -749,32 +742,26 @@ const StyledEditor = styled("div")<{
     margin: 1em 0 0.5em;
     font-weight: 500;
     cursor: default;
-
     &:not(.placeholder):before {
-      display: ${props => (props.readOnly ? "none" : "inline")};
-      position: relative;
+      display: ${props => (props.readOnly ? "none" : "block")};
+      position: absolute;
       font-family: ${props => props.theme.fontFamilyMono};
       color: ${props => props.theme.textSecondary};
       font-size: 13px;
-      margin-right: -16px;
-      left: -20px;
+      left: -24px;
     }
-
     &:hover {
       .heading-anchor {
         opacity: 1;
       }
     }
   }
-
   .heading-name {
     color: ${props => props.theme.text};
-
     &:hover {
       text-decoration: none;
     }
   }
-
   a:first-child {
     h1,
     h2,
@@ -785,18 +772,21 @@ const StyledEditor = styled("div")<{
       margin-top: 0;
     }
   }
-
   h1:not(.placeholder):before {
     content: "H1";
+    line-height: 3em;
   }
   h2:not(.placeholder):before {
     content: "H2";
+    line-height: 2.8em;
   }
   h3:not(.placeholder):before {
     content: "H3";
+    line-height: 2.3em;
   }
   h4:not(.placeholder):before {
     content: "H4";
+    line-height: 2.2em;
   }
   h5:not(.placeholder):before {
     content: "H5";
@@ -804,14 +794,12 @@ const StyledEditor = styled("div")<{
   h6:not(.placeholder):before {
     content: "H6";
   }
-
   .with-emoji {
     margin-left: -1em;
   }
-
   .heading-anchor {
     opacity: 0;
-    display: ${props => (props.readOnly ? "inline" : "none")};
+    display: ${props => (props.readOnly ? "block" : "none")};
     color: ${props => props.theme.textSecondary};
     cursor: pointer;
     background: none;
@@ -819,17 +807,23 @@ const StyledEditor = styled("div")<{
     outline: none;
     padding: 2px 12px 2px 4px;
     margin: 0;
-    position: relative;
-    margin-right: -30px;
-    left: -20px;
+    position: absolute;
     transition: opacity 100ms ease-in-out;
     font-family: ${props => props.theme.fontFamilyMono};
     font-size: 22px;
     left: -1.3em;
-
     &:focus,
     &:hover {
       color: ${props => props.theme.text};
+    }
+  }
+  .placeholder {
+    &:before {
+      display: block;
+      content: ${props => (props.readOnly ? "" : "attr(data-empty-text)")};
+      pointer-events: none;
+      height: 0;
+      color: ${props => props.theme.placeholder};
     }
   }
 

--- a/src/menus/image.tsx
+++ b/src/menus/image.tsx
@@ -1,6 +1,5 @@
 import {
   TrashIcon,
-  AlignImageLeftIcon,
   AlignImageRightIcon,
   AlignImageCenterIcon,
 } from "outline-icons";
@@ -14,30 +13,18 @@ export default function imageMenuItems(
   dictionary: typeof baseDictionary
 ): MenuItem[] {
   const { schema } = state;
-  const isLeftAligned = isNodeActive(schema.nodes.image, {
-    layoutClass: "left-50",
-  });
   const isRightAligned = isNodeActive(schema.nodes.image, {
     layoutClass: "right-50",
   });
 
   return [
     {
-      name: "alignLeft",
-      tooltip: dictionary.alignLeft,
-      icon: AlignImageLeftIcon,
-      visible: true,
-      active: isLeftAligned,
-    },
-    {
       name: "alignCenter",
       tooltip: dictionary.alignCenter,
       icon: AlignImageCenterIcon,
       visible: true,
       active: state =>
-        isNodeActive(schema.nodes.image)(state) &&
-        !isLeftAligned(state) &&
-        !isRightAligned(state),
+        isNodeActive(schema.nodes.image)(state) && !isRightAligned(state),
     },
     {
       name: "alignRight",

--- a/src/nodes/Image.tsx
+++ b/src/nodes/Image.tsx
@@ -83,7 +83,7 @@ const uploadPlugin = options =>
     },
   });
 
-const IMAGE_CLASSES = ["right-50", "left-50"];
+const IMAGE_CLASSES = ["right-50"];
 const getLayoutAndTitle = tokenTitle => {
   if (!tokenTitle) return {};
   if (IMAGE_CLASSES.includes(tokenTitle)) {
@@ -292,16 +292,6 @@ export default class Image extends Node {
           ...state.selection.node.attrs,
           title: null,
           layoutClass: "right-50",
-        };
-        const { selection } = state;
-        dispatch(state.tr.setNodeMarkup(selection.$from.pos, undefined, attrs));
-        return true;
-      },
-      alignLeft: () => (state, dispatch) => {
-        const attrs = {
-          ...state.selection.node.attrs,
-          title: null,
-          layoutClass: "left-50",
         };
         const { selection } = state;
         dispatch(state.tr.setNodeMarkup(selection.$from.pos, undefined, attrs));


### PR DESCRIPTION
This reverts the header styles prior to the creation of the image alignment PR, as I simply found it impossible to fix the header styling in a way that worked with both copying the old functionality and also working alongside a left-aligned image.