### PR TITLE
fix: Caret size at beginning of headers

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -751,13 +751,13 @@ const StyledEditor = styled("div")<{
     cursor: default;
 
     &:not(.placeholder):before {
-      display: ${props => (props.readOnly ? "none" : "inline")};
-      position: relative;
+      display: ${props => (props.readOnly ? "none" : "inline-block")};
       font-family: ${props => props.theme.fontFamilyMono};
       color: ${props => props.theme.textSecondary};
       font-size: 13px;
-      margin-right: -16px;
-      left: -20px;
+      line-height: 0;
+      margin-left: -24px;
+      width: 24px;
     }
 
     &:hover {
@@ -766,7 +766,12 @@ const StyledEditor = styled("div")<{
       }
     }
   }
-
+  .heading-content {
+    &:before {
+      content: "​";
+      display: inline;
+    }
+  }
   .heading-name {
     color: ${props => props.theme.text};
 
@@ -811,7 +816,7 @@ const StyledEditor = styled("div")<{
 
   .heading-anchor {
     opacity: 0;
-    display: ${props => (props.readOnly ? "inline" : "none")};
+    display: ${props => (props.readOnly ? "inline-block" : "none")};
     color: ${props => props.theme.textSecondary};
     cursor: pointer;
     background: none;
@@ -819,13 +824,12 @@ const StyledEditor = styled("div")<{
     outline: none;
     padding: 2px 12px 2px 4px;
     margin: 0;
-    position: relative;
-    margin-right: -30px;
-    left: -20px;
     transition: opacity 100ms ease-in-out;
     font-family: ${props => props.theme.fontFamilyMono};
     font-size: 22px;
-    left: -1.3em;
+    line-height: 0;
+    margin-left: -24px;
+    width: 24px;
 
     &:focus,
     &:hover {

--- a/src/nodes/Heading.ts
+++ b/src/nodes/Heading.ts
@@ -50,7 +50,7 @@ export default class Heading extends Node {
         return [
           `h${node.attrs.level + (this.options.offset || 0)}`,
           button,
-          ["span", 0],
+          ["span", { class: "heading-content" }, 0],
         ];
       },
     };


### PR DESCRIPTION
This relies on a "hack", introducing an invisible character between the start of the heading text and the "H1" before content so that the caret is never possible to be placed next to the "H1" ::before content.

In my testing in Chrome and Firefox this actually works really well. @cliftonc take a look, let me know what you think?

alternative to https://github.com/outline/rich-markdown-editor/pull/353
closes #350