### PR TITLE
Modify main marks regexes to not trigger half-way through words

### DIFF
--- a/src/marks/Bold.ts
+++ b/src/marks/Bold.ts
@@ -19,7 +19,7 @@ export default class Bold extends Mark {
   }
 
   inputRules({ type }) {
-    return [markInputRule(/(?:\*\*)([^*]+)(?:\*\*)$/, type)];
+    return [markInputRule(/(?:\*\*)([^*\S]+)(?:\*\*)$/, type)];
   }
 
   keys({ type }) {

--- a/src/marks/Code.ts
+++ b/src/marks/Code.ts
@@ -37,7 +37,7 @@ export default class Code extends Mark {
   }
 
   inputRules({ type }) {
-    return [markInputRule(/(?:^|[^`])(`([^`]+)`)$/, type)];
+    return [markInputRule(/(?:^|[^`\S])(`([^`]+)`)$/, type)];
   }
 
   keys({ type }) {

--- a/src/marks/Italic.ts
+++ b/src/marks/Italic.ts
@@ -12,7 +12,7 @@ export default class Italic extends Mark {
       parseDOM: [
         { tag: "i" },
         { tag: "em" },
-        { style: "font-style", getAttrs: value => value === "italic" },
+        { style: "font-style", getAttrs: (value) => value === "italic" },
       ],
       toDOM: () => ["em"],
     };
@@ -20,8 +20,8 @@ export default class Italic extends Mark {
 
   inputRules({ type }) {
     return [
-      markInputRule(/(?:^|[^_])(_([^_]+)_)$/, type),
-      markInputRule(/(?:^|[^*])(\*([^*]+)\*)$/, type),
+      markInputRule(/(?:^|[^_\S])(_([^_]+)_)$/, type),
+      markInputRule(/(?:^|[^*\S])(\*([^*]+)\*)$/, type),
     ];
   }
 

--- a/src/marks/Strikethrough.ts
+++ b/src/marks/Strikethrough.ts
@@ -31,7 +31,7 @@ export default class Strikethrough extends Mark {
   }
 
   inputRules({ type }) {
-    return [markInputRule(/~([^~]+)~$/, type)];
+    return [markInputRule(/~([^~\S]+)~$/, type)];
   }
 
   get toMarkdown() {


### PR DESCRIPTION
Proposal of regex changes to avoid toggling a style change while typing a word.
Not sure if this is too specific, but I often write variable or function names in the code and if they are in snakecase, this makes it impossible to write them due to italic constantly triggering.
Example:

this_variable_name cannot be written as it will turn into this _variable_ name (cannot replicate perfectly in github, need to surround "variable" with spaces).

I hope this makes sense!