### PR TITLE
Fix Interference of External Styling with Floating Toolbar Menu

### DIFF
--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { EditorView } from "prosemirror-view";
-import { withTheme } from "styled-components";
+import styled, { withTheme } from "styled-components";
 import ToolbarButton from "./ToolbarButton";
 import ToolbarSeparator from "./ToolbarSeparator";
 import theme from "../theme";
@@ -14,6 +14,10 @@ type Props = {
   items: MenuItem[];
 };
 
+const FlexibleWrapper = styled.div`
+  display: flex;
+`;
+
 class Menu extends React.Component<Props> {
   render() {
     const { view, items } = this.props;
@@ -21,7 +25,7 @@ class Menu extends React.Component<Props> {
     const Tooltip = this.props.tooltip;
 
     return (
-      <div>
+      <FlexibleWrapper>
         {items.map((item, index) => {
           if (item.name === "separator" && item.visible !== false) {
             return <ToolbarSeparator key={index} />;
@@ -46,7 +50,7 @@ class Menu extends React.Component<Props> {
             </ToolbarButton>
           );
         })}
-      </div>
+      </FlexibleWrapper>
     );
   }
 }


### PR DESCRIPTION
As explained in #301, the floating toolbar's menu is susceptible to external styling, e.g., from [`bootstrap`](https://getbootstrap.com/) and [`bootswatch`](https://bootswatch.com/). Since I ran into the same issue and there hasn't been any progress on #301, I would like to fix the issue with this PR. As [requested](https://github.com/outline/rich-markdown-editor/pull/301#issuecomment-705288508) by @tommoor, this fix uses `styled-components`. Happy about your feedback!