### PR TITLE
chore: Add onFocus, onBlur callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,18 @@ If you want the editor to support images then this callback must be provided. Th
 />
 ```
 
+#### `onBlur(): void`
+
+This callback is triggered when the user loses focus on the editor contenteditable and all
+associated UI elements such as the block menu and floating toolbars. If you want to listen
+for blur events on _only_ the contenteditable area then use `handleDOMEvents` props.
+
+#### `onFocus(): void`
+
+This callback is triggered when the user gains focus on the editor contenteditable or any
+associated UI elements such as the block menu or floating toolbars. If you want to listen
+for focus events on _only_ the contenteditable area then use `handleDOMEvents` props.
+
 #### `onSave({ done: boolean }): void`
 
 This callback is triggered when the user explicitly requests to save using a keyboard shortcut, `Cmd+S` or `Cmd+Enter`. You can use this as a signal to save the document to a remote server.

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -131,12 +131,8 @@ class Example extends React.Component {
           template={this.state.template}
           defaultValue={defaultValue}
           scrollTo={window.location.hash}
-          handleDOMEvents={{
-            focus: () => console.log("FOCUS"),
-            blur: () => console.log("BLUR"),
-            paste: () => console.log("PASTE"),
-            touchstart: () => console.log("TOUCH START"),
-          }}
+          onBlur={() => console.log("onBlur")}
+          onFocus={() => console.log("onFocus")}
           onSave={options => console.log("Save triggered", options)}
           onCancel={() => console.log("Cancel triggered")}
           onChange={this.handleChange}

--- a/src/components/SelectionToolbar.tsx
+++ b/src/components/SelectionToolbar.tsx
@@ -25,6 +25,8 @@ type Props = {
   tooltip: typeof React.Component | React.FC<any>;
   isTemplate: boolean;
   commands: Record<string, any>;
+  onOpen: () => void;
+  onClose: () => void;
   onSearchLink?: (term: string) => Promise<SearchResult[]>;
   onClickLink: (href: string, event: MouseEvent) => void;
   onCreateLink?: (title: string) => Promise<string>;
@@ -32,7 +34,7 @@ type Props = {
   view: EditorView;
 };
 
-function isActive(props) {
+function isVisible(props) {
   const { view } = props;
   const { selection } = view.state;
 
@@ -51,6 +53,20 @@ function isActive(props) {
 }
 
 export default class SelectionToolbar extends React.Component<Props> {
+  isActive = false;
+
+  componentDidUpdate(): void {
+    const visible = isVisible(this.props);
+    if (this.isActive && !visible) {
+      this.isActive = false;
+      this.props.onClose();
+    }
+    if (!this.isActive && visible) {
+      this.isActive = true;
+      this.props.onOpen();
+    }
+  }
+
   handleOnCreateLink = async (title: string) => {
     const { dictionary, onCreateLink, view, onShowToast } = this.props;
 
@@ -139,7 +155,7 @@ export default class SelectionToolbar extends React.Component<Props> {
 
     return (
       <Portal>
-        <FloatingToolbar view={view} active={isActive(this.props)}>
+        <FloatingToolbar view={view} active={isVisible(this.props)}>
           {link && range ? (
             <LinkEditor
               dictionary={dictionary}

--- a/src/plugins/Keys.ts
+++ b/src/plugins/Keys.ts
@@ -10,6 +10,10 @@ export default class Keys extends Extension {
     return [
       new Plugin({
         props: {
+          handleDOMEvents: {
+            blur: this.options.onBlur,
+            focus: this.options.onFocus,
+          },
           // we can't use the keys bindings for this as we want to preventDefault
           // on the original keyboard event when handled
           handleKeyDown: (view, event) => {


### PR DESCRIPTION
#### `onBlur(): void`

This callback is triggered when the user loses focus on the editor contenteditable and all
associated UI elements such as the block menu and floating toolbars. If you want to listen
for blur events on _only_ the contenteditable area then use `handleDOMEvents` props.

#### `onFocus(): void`

This callback is triggered when the user gains focus on the editor contenteditable or any
associated UI elements such as the block menu or floating toolbars. If you want to listen
for focus events on _only_ the contenteditable area then use `handleDOMEvents` props.
