### PR TITLE
fix: Remove embed component from prosemirror attrs 

### DIFF
--- a/src/lib/markdown/embeds.ts
+++ b/src/lib/markdown/embeds.ts
@@ -70,7 +70,6 @@ export default function(embeds) {
                 // convert to embed token
                 const token = new Token("embed", "iframe", 0);
                 token.attrSet("href", content);
-                token.attrSet("component", result.component);
                 token.attrSet("matches", result.matches);
 
                 // delete the inline link – this makes the assumption that the


### PR DESCRIPTION
Having a React component inside the Prosemirror attrs was not good for compatibility with other data stores, such as yjs.

closes #392
cc @aulneau