### PR TITLE
feat: add yaml support

### DIFF
--- a/src/nodes/CodeFence.ts
+++ b/src/nodes/CodeFence.ts
@@ -14,6 +14,7 @@ import powershell from "refractor/lang/powershell";
 import ruby from "refractor/lang/ruby";
 import sql from "refractor/lang/sql";
 import typescript from "refractor/lang/typescript";
+import yaml from "refractor/lang/yaml";
 import { setBlockType } from "prosemirror-commands";
 import { textblockTypeInputRule } from "prosemirror-inputrules";
 import copy from "copy-to-clipboard";
@@ -38,6 +39,7 @@ import { ToastType } from "../types";
   ruby,
   sql,
   typescript,
+  yaml,
 ].forEach(refractor.register);
 
 export default class CodeFence extends Node {

--- a/src/plugins/Prism.ts
+++ b/src/plugins/Prism.ts
@@ -21,6 +21,7 @@ export const LANGUAGES = {
   ruby: "Ruby",
   sql: "SQL",
   typescript: "TypeScript",
+  yaml: "Yaml",
 };
 
 type ParsedNode = {

--- a/src/plugins/Prism.ts
+++ b/src/plugins/Prism.ts
@@ -21,7 +21,7 @@ export const LANGUAGES = {
   ruby: "Ruby",
   sql: "SQL",
   typescript: "TypeScript",
-  yaml: "Yaml",
+  yaml: "YAML",
 };
 
 type ParsedNode = {


### PR DESCRIPTION
Yaml is one of most used file format. Could be a nice to have it by default on rich-markdown-editor.