### PR TITLE
feat: Math / KaTeX

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lodash": "^4.17.11",
     "markdown-it-container": "^3.0.0",
     "markdown-it-mathjax": "^2.0.0",
-    "outline-icons": "^1.25.1-1",
+    "outline-icons": "^1.27.0",
     "prosemirror-commands": "^1.1.6",
     "prosemirror-dropcursor": "^1.3.3",
     "prosemirror-gapcursor": "^1.1.5",

--- a/package.json
+++ b/package.json
@@ -25,9 +25,12 @@
     ]
   },
   "dependencies": {
+    "@benrbray/prosemirror-math": "^0.1.4",
     "copy-to-clipboard": "^3.0.8",
+    "katex": "^0.13.3",
     "lodash": "^4.17.11",
     "markdown-it-container": "^3.0.0",
+    "markdown-it-mathjax": "^2.0.0",
     "outline-icons": "^1.25.1-1",
     "prosemirror-commands": "^1.1.6",
     "prosemirror-dropcursor": "^1.3.3",
@@ -56,14 +59,14 @@
     "styled-components": "^5.0.0"
   },
   "devDependencies": {
+    "@babel/core": "^7.12.16",
     "@babel/preset-env": "^7.12.11",
     "@babel/preset-typescript": "^7.12.7",
-    "@types/jest": "^26.0.20",
-    "@babel/core": "^7.12.16",
     "@storybook/addon-actions": "^6.1.17",
     "@storybook/addon-essentials": "^6.1.17",
     "@storybook/addon-links": "^6.1.17",
     "@storybook/react": "^6.1.17",
+    "@types/jest": "^26.0.20",
     "@types/lodash": "^4.14.149",
     "@types/markdown-it": "^10.0.1",
     "@types/prosemirror-commands": "^1.0.1",
@@ -99,9 +102,9 @@
     "react-dom": "^17.0.0",
     "source-map-loader": "^0.2.4",
     "styled-components": "^5.2.1",
-    "typescript": "3.9.7",
     "ts-loader": "^6.2.1",
-    "tsc-watch": "^4.2.9"
+    "tsc-watch": "^4.2.9",
+    "typescript": "3.9.7"
   },
   "resolutions": {
     "yargs-parser": "^15.0.1"

--- a/src/dictionary.ts
+++ b/src/dictionary.ts
@@ -36,6 +36,7 @@ export const base = {
   link: "Link",
   linkCopied: "Link copied to clipboard",
   mark: "Highlight",
+  math: "Math",
   newLineEmpty: "Type '/' to insert…",
   newLineWithSlash: "Keep typing to filter…",
   noResults: "No results",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -42,6 +42,8 @@ import Heading from "./nodes/Heading";
 import HorizontalRule from "./nodes/HorizontalRule";
 import Image from "./nodes/Image";
 import ListItem from "./nodes/ListItem";
+import Math from "./nodes/Math";
+import MathDisplay from "./nodes/MathDisplay";
 import Notice from "./nodes/Notice";
 import OrderedList from "./nodes/OrderedList";
 import Paragraph from "./nodes/Paragraph";
@@ -305,6 +307,8 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
         new Code(),
         new Highlight(),
         new Italic(),
+        new Math(),
+        new MathDisplay(),
         new TemplatePlaceholder(),
         new Underline(),
         new Link({

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -25,6 +25,7 @@ import Extension from "./lib/Extension";
 import ExtensionManager from "./lib/ExtensionManager";
 import ComponentView from "./lib/ComponentView";
 import headingToSlug from "./lib/headingToSlug";
+import { mathSerializer } from "@benrbray/prosemirror-math";
 
 // nodes
 import ReactNode from "./nodes/ReactNode";
@@ -458,6 +459,7 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
       editable: () => !this.props.readOnly,
       nodeViews: this.nodeViews,
       handleDOMEvents: this.props.handleDOMEvents,
+      clipboardTextSerializer: slice => mathSerializer.serializeSlice(slice),
       dispatchTransaction: transaction => {
         const { state, transactions } = this.view.state.applyTransaction(
           transaction

--- a/src/lib/markdown/math.ts
+++ b/src/lib/markdown/math.ts
@@ -1,0 +1,138 @@
+// based on https://raw.githubusercontent.com/classeur/markdown-it-mathjax/master/markdown-it-mathjax.js
+// token names needed to be flipped e.g. display_math -> math_display to work with prosemirror-math
+
+function math(state, silent) {
+  let startMathPos = state.pos;
+  if (state.src.charCodeAt(startMathPos) !== 0x5c /* \ */) {
+    return false;
+  }
+  const match = state.src
+    .slice(++startMathPos)
+    .match(/^(?:\\\[|\\\(|begin\{([^}]*)\})/);
+  if (!match) {
+    return false;
+  }
+  startMathPos += match[0].length;
+  let type, endMarker, includeMarkers;
+  if (match[0] === "\\[") {
+    type = "math_display";
+    endMarker = "\\\\]";
+  } else if (match[0] === "\\(") {
+    type = "math_inline";
+    endMarker = "\\\\)";
+  } else if (match[1]) {
+    type = "math";
+    endMarker = "\\end{" + match[1] + "}";
+    includeMarkers = true;
+  }
+  const endMarkerPos = state.src.indexOf(endMarker, startMathPos);
+  if (endMarkerPos === -1) {
+    return false;
+  }
+  const nextPos = endMarkerPos + endMarker.length;
+  if (!silent) {
+    const token = state.push(type, "", 0);
+    token.content = includeMarkers
+      ? state.src.slice(state.pos, nextPos)
+      : state.src.slice(startMathPos, endMarkerPos);
+  }
+  state.pos = nextPos;
+  return true;
+}
+
+function texMath(state, silent) {
+  let startMathPos = state.pos;
+  if (state.src.charCodeAt(startMathPos) !== 0x24 /* $ */) {
+    return false;
+  }
+
+  // Parse tex math according to http://pandoc.org/README.html#math
+  let endMarker = "$";
+  const afterStartMarker = state.src.charCodeAt(++startMathPos);
+  if (afterStartMarker === 0x24 /* $ */) {
+    endMarker = "$$";
+    if (state.src.charCodeAt(++startMathPos) === 0x24 /* $ */) {
+      // 3 markers are too much
+      return false;
+    }
+  } else {
+    // Skip if opening $ is succeeded by a space character
+    if (
+      afterStartMarker === 0x20 /* space */ ||
+      afterStartMarker === 0x09 /* \t */ ||
+      afterStartMarker === 0x0a /* \n */
+    ) {
+      return false;
+    }
+  }
+  const endMarkerPos = state.src.indexOf(endMarker, startMathPos);
+  if (endMarkerPos === -1) {
+    return false;
+  }
+  if (state.src.charCodeAt(endMarkerPos - 1) === 0x5c /* \ */) {
+    return false;
+  }
+  const nextPos = endMarkerPos + endMarker.length;
+  if (endMarker.length === 1) {
+    // Skip if $ is preceded by a space character
+    const beforeEndMarker = state.src.charCodeAt(endMarkerPos - 1);
+    if (
+      beforeEndMarker === 0x20 /* space */ ||
+      beforeEndMarker === 0x09 /* \t */ ||
+      beforeEndMarker === 0x0a /* \n */
+    ) {
+      return false;
+    }
+    // Skip if closing $ is succeeded by a digit (eg $5 $10 ...)
+    const suffix = state.src.charCodeAt(nextPos);
+    if (suffix >= 0x30 && suffix < 0x3a) {
+      return false;
+    }
+  }
+
+  if (!silent) {
+    const token = state.push(
+      endMarker.length === 1 ? "math_inline" : "math_display",
+      "",
+      0
+    );
+    token.content = state.src.slice(startMathPos, endMarkerPos);
+  }
+  state.pos = nextPos;
+  return true;
+}
+
+function escapeHtml(html) {
+  return html
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/\u00a0/g, " ");
+}
+
+const mapping = {
+  math: "Math",
+  math_inline: "InlineMath",
+  math_display: "DisplayMath",
+};
+
+const options = {
+  beforeMath: "",
+  afterMath: "",
+  beforeInlineMath: "\\(",
+  afterInlineMath: "\\)",
+  beforeDisplayMath: "\\[",
+  afterDisplayMath: "\\]",
+};
+
+export default function(md) {
+  md.inline.ruler.before("escape", "math", math);
+  md.inline.ruler.push("texMath", texMath);
+
+  Object.keys(mapping).forEach(function(key) {
+    const before = options["before" + mapping[key]];
+    const after = options["after" + mapping[key]];
+    md.renderer.rules[key] = function(tokens, idx) {
+      return before + escapeHtml(tokens[idx].content) + after;
+    };
+  });
+}

--- a/src/lib/markdown/rules.ts
+++ b/src/lib/markdown/rules.ts
@@ -1,4 +1,5 @@
 import markdownit from "markdown-it";
+import mathPlugin from "./math";
 import markPlugin from "./mark";
 import checkboxPlugin from "./checkboxes";
 import embedsPlugin from "./embeds";
@@ -20,5 +21,6 @@ export default function rules({ embeds }) {
     .use(markPlugin({ delim: "!!", mark: "placeholder" }))
     .use(underlinesPlugin)
     .use(tablesPlugin)
+    .use(mathPlugin)
     .use(noticesPlugin);
 }

--- a/src/menus/block.ts
+++ b/src/menus/block.ts
@@ -6,6 +6,7 @@ import {
   Heading2Icon,
   Heading3Icon,
   HorizontalRuleIcon,
+  MathIcon,
   OrderedListIcon,
   TableIcon,
   TodoListIcon,
@@ -93,6 +94,11 @@ export default function blockMenuItems(
       icon: CodeIcon,
       shortcut: "^ ⇧ \\",
       keywords: "script",
+    },
+    {
+      name: "math_display",
+      title: dictionary.math,
+      icon: MathIcon,
     },
     {
       name: "hr",

--- a/src/nodes/Math.ts
+++ b/src/nodes/Math.ts
@@ -39,6 +39,10 @@ export default class Math extends Node {
     };
   }
 
+  commands({ type }) {
+    return () => insertMathCmd(type);
+  }
+
   inputRules({ schema }) {
     return [
       makeInlineMathInputRule(
@@ -48,9 +52,9 @@ export default class Math extends Node {
     ];
   }
 
-  keys({ schema }) {
+  keys({ type }) {
     return {
-      "Mod-Space": insertMathCmd(schema.nodes.math_inline),
+      "Mod-Space": insertMathCmd(type),
       Backspace: chainCommands(
         deleteSelection,
         mathBackspaceCmd,

--- a/src/nodes/Math.ts
+++ b/src/nodes/Math.ts
@@ -1,0 +1,78 @@
+import {
+  chainCommands,
+  deleteSelection,
+  selectNodeBackward,
+  joinBackward,
+} from "prosemirror-commands";
+import {
+  mathPlugin,
+  mathBackspaceCmd,
+  insertMathCmd,
+  makeInlineMathInputRule,
+  REGEX_INLINE_MATH_DOLLARS,
+} from "@benrbray/prosemirror-math";
+import Node from "./Node";
+import "katex/dist/katex.min.css";
+import "@benrbray/prosemirror-math/style/math.css";
+
+export default class Math extends Node {
+  get name() {
+    return "math_inline";
+  }
+
+  get schema() {
+    return {
+      group: "inline math",
+      content: "text*",
+      inline: true,
+      atom: true,
+      toDOM: () => [
+        "math-inline",
+        { class: "math-node", spellcheck: "false" },
+        0,
+      ],
+      parseDOM: [
+        {
+          tag: "math-inline",
+        },
+      ],
+    };
+  }
+
+  inputRules({ schema }) {
+    return [
+      makeInlineMathInputRule(
+        REGEX_INLINE_MATH_DOLLARS,
+        schema.nodes.math_inline
+      ),
+    ];
+  }
+
+  keys({ schema }) {
+    return {
+      "Mod-Space": insertMathCmd(schema.nodes.math_inline),
+      Backspace: chainCommands(
+        deleteSelection,
+        mathBackspaceCmd,
+        joinBackward,
+        selectNodeBackward
+      ),
+    };
+  }
+
+  get plugins() {
+    return [mathPlugin];
+  }
+
+  toMarkdown(state, node) {
+    state.write("$");
+    state.renderInline(node);
+    state.write("$");
+  }
+
+  parseMarkdown() {
+    return {
+      node: "math_inline",
+    };
+  }
+}

--- a/src/nodes/MathDisplay.ts
+++ b/src/nodes/MathDisplay.ts
@@ -1,6 +1,7 @@
 import {
   makeBlockMathInputRule,
   REGEX_BLOCK_MATH_DOLLARS,
+  insertMathCmd,
 } from "@benrbray/prosemirror-math";
 import Node from "./Node";
 
@@ -28,13 +29,12 @@ export default class MathDisplay extends Node {
     };
   }
 
-  inputRules({ schema }) {
-    return [
-      makeBlockMathInputRule(
-        REGEX_BLOCK_MATH_DOLLARS,
-        schema.nodes.math_display
-      ),
-    ];
+  commands({ type }) {
+    return () => insertMathCmd(type);
+  }
+
+  inputRules({ type }) {
+    return [makeBlockMathInputRule(REGEX_BLOCK_MATH_DOLLARS, type)];
   }
 
   toMarkdown(state, node) {

--- a/src/nodes/MathDisplay.ts
+++ b/src/nodes/MathDisplay.ts
@@ -1,0 +1,53 @@
+import {
+  makeBlockMathInputRule,
+  REGEX_BLOCK_MATH_DOLLARS,
+} from "@benrbray/prosemirror-math";
+import Node from "./Node";
+
+export default class MathDisplay extends Node {
+  get name() {
+    return "math_display";
+  }
+
+  get schema() {
+    return {
+      group: "block math",
+      content: "text*",
+      atom: true,
+      code: true,
+      toDOM: () => [
+        "math-display",
+        { class: "math-node", spellcheck: "false" },
+        0,
+      ],
+      parseDOM: [
+        {
+          tag: "math-display",
+        },
+      ],
+    };
+  }
+
+  inputRules({ schema }) {
+    return [
+      makeBlockMathInputRule(
+        REGEX_BLOCK_MATH_DOLLARS,
+        schema.nodes.math_display
+      ),
+    ];
+  }
+
+  toMarkdown(state, node) {
+    state.write("$$\n");
+    state.text(node.textContent, false);
+    state.ensureNewLine();
+    state.write("$$");
+    state.closeBlock(node);
+  }
+
+  parseMarkdown() {
+    return {
+      node: "math_display",
+    };
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9495,10 +9495,10 @@ os-tmpdir@~1.0.2:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
-outline-icons@^1.25.1-1:
-  version "1.25.1-1"
-  resolved "https://registry.yarnpkg.com/outline-icons/-/outline-icons-1.25.1-1.tgz#1d17b478283181fd360f43498421a8b63f3fd9e0"
-  integrity sha512-rnTl/v2nMabiyCmsL9WmVz2PoZXNEO135MULXUTVtTmWo6KGWsl4B9ug8dxw4MR08fIiJt5niwQsE2EDlH6n6A==
+outline-icons@^1.27.0:
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/outline-icons/-/outline-icons-1.27.0.tgz#0d923a0b81fe2f3eac1ee5ffe9617158d41e4c29"
+  integrity sha512-YGm0IjCGO3+dduESI4aU/VMmu5uVJwsbStGn6+fRVZLryv2HEFcfofgF93AvPnc8AdFgF9xwzyYisnzpLjhPbA==
 
 overlayscrollbars@^1.10.2:
   version "1.13.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1700,6 +1700,11 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@benrbray/prosemirror-math@^0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@benrbray/prosemirror-math/-/prosemirror-math-0.1.4.tgz#2390b7a94696c6d1d8700c6b6a8712ba81208958"
+  integrity sha512-Mlr9rChTD7wWmd5rSjjAL+OPWsHK6RlO+bprf0vrVCQhmmBTA1S8ZzRKPx5TymmtmvViVytKOk8vBXjg7EwbFg==
+
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"
@@ -4947,6 +4952,11 @@ commander@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
   integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
+
+commander@^6.0.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
+  integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -8490,6 +8500,13 @@ junk@^3.1.0:
   resolved "https://registry.yarnpkg.com/junk/-/junk-3.1.0.tgz#31499098d902b7e98c5d9b9c80f43457a88abfa1"
   integrity sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ==
 
+katex@^0.13.3:
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/katex/-/katex-0.13.3.tgz#b7b1f4a8de496ea8bfe60ab0b5e1822864288f00"
+  integrity sha512-/w0eycuK1xh201T0uFXYOZWPDoeqDHqR+6SLLKsYvNtUCYtmRjq8F+M74sdpzs+dJZYWv2eUsSW0r1AJfhZOCw==
+  dependencies:
+    commander "^6.0.0"
+
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
@@ -8756,6 +8773,11 @@ markdown-it-container@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/markdown-it-container/-/markdown-it-container-3.0.0.tgz#1d19b06040a020f9a827577bb7dbf67aa5de9a5b"
   integrity sha512-y6oKTq4BB9OQuY/KLfk/O3ysFhB3IMYoIWhGJEidXt1NQFocFK2sA2t0NYZAMyMShAGL6x5OPIbrmXPIqaN9rw==
+
+markdown-it-mathjax@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-it-mathjax/-/markdown-it-mathjax-2.0.0.tgz#ae2b4f4c5c719a03f9e475c664f7b2685231d9e9"
+  integrity sha1-ritPTFxxmgP55HXGZPeyaFIx2ek=
 
 markdown-it@^10.0.0:
   version "10.0.0"


### PR DESCRIPTION
Proof of concept using `prosemirror-math` to manage flipping between KaTeX and an editable math expression. Note that including this in Outline as it stands would probably be a blocker for collab editing, as it lacks support.

### TODO

- [ ] Respect `readOnly`
- [ ] Add to block menu
- [ ] Fix content not rehydrated from markdown persistence 
- [ ] Support for async loading https://github.com/benrbray/prosemirror-math/issues/22
- [ ] Refine styling

related https://github.com/outline/outline/issues/1038