### PR TITLE
Disable extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ When set enforces a maximum character length on the document, not including mark
 
 Allows additional [Prosemirror plugins](https://prosemirror.net/docs/ref/#state.Plugin_System) to be passed to the underlying Prosemirror instance.
 
+#### `disableExtensions`
+
+List of included extension names to disable. Removes corresponding menu items and commands. E.g. set to `["em", "blockquote"]` to disable italic text and blockquotes.
+
 #### `theme`
 
 Allows overriding the inbuilt theme to brand the editor, for example use your own font face and brand colors to have the editor fit within your application. See the [inbuilt theme](/src/theme.ts) for an example of the keys that should be provided.

--- a/src/components/BlockMenu.tsx
+++ b/src/components/BlockMenu.tsx
@@ -380,7 +380,13 @@ class BlockMenu extends React.Component<Props, State> {
   }
 
   get filtered() {
-    const { dictionary, embeds, search = "", uploadImage } = this.props;
+    const {
+      dictionary,
+      embeds,
+      search = "",
+      uploadImage,
+      commands,
+    } = this.props;
     let items: (EmbedDescriptor | MenuItem)[] = getMenuItems(dictionary);
     const embedItems: EmbedDescriptor[] = [];
 
@@ -402,6 +408,9 @@ class BlockMenu extends React.Component<Props, State> {
 
     const filtered = items.filter(item => {
       if (item.name === "separator") return true;
+
+      // Some extensions may be disabled, remove corresponding menu items
+      if (item.name && !commands[item.name]) return false;
 
       // If no image upload callback has been passed, filter the image block out
       if (!uploadImage && item.name === "image") return false;

--- a/src/components/SelectionToolbar.tsx
+++ b/src/components/SelectionToolbar.tsx
@@ -156,6 +156,12 @@ export default class SelectionToolbar extends React.Component<Props> {
       items = getFormattingMenuItems(state, isTemplate, dictionary);
     }
 
+    // Some extensions may be disabled, remove corresponding items
+    items = items.filter(item => {
+      if (item.name && !this.props.commands[item.name]) return false;
+      return true;
+    });
+
     if (!items.length) {
       return null;
     }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -82,6 +82,7 @@ export type Props = {
   defaultValue: string;
   placeholder: string;
   extensions: Extension[];
+  disableExtensions?: string[];
   autoFocus?: boolean;
   readOnly?: boolean;
   readOnlyWriteCheckboxes?: boolean;
@@ -258,84 +259,92 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
     // adding nodes here? Update schema.ts for serialization on the server
     return new ExtensionManager(
       [
-        new Doc(),
-        new Text(),
-        new HardBreak(),
-        new Paragraph(),
-        new Blockquote(),
-        new CodeBlock({
-          dictionary,
-          onShowToast: this.props.onShowToast,
-        }),
-        new CodeFence({
-          dictionary,
-          onShowToast: this.props.onShowToast,
-        }),
-        new CheckboxList(),
-        new CheckboxItem(),
-        new BulletList(),
-        new Embed(),
-        new ListItem(),
-        new Notice({
-          dictionary,
-        }),
-        new Heading({
-          dictionary,
-          onShowToast: this.props.onShowToast,
-          offset: this.props.headingsOffset,
-        }),
-        new HorizontalRule(),
-        new Image({
-          dictionary,
-          uploadImage: this.props.uploadImage,
-          onImageUploadStart: this.props.onImageUploadStart,
-          onImageUploadStop: this.props.onImageUploadStop,
-          onShowToast: this.props.onShowToast,
-        }),
-        new Table(),
-        new TableCell({
-          onSelectTable: this.handleSelectTable,
-          onSelectRow: this.handleSelectRow,
-        }),
-        new TableHeadCell({
-          onSelectColumn: this.handleSelectColumn,
-        }),
-        new TableRow(),
-        new Bold(),
-        new Code(),
-        new Highlight(),
-        new Italic(),
-        new TemplatePlaceholder(),
-        new Underline(),
-        new Link({
-          onKeyboardShortcut: this.handleOpenLinkMenu,
-          onClickLink: this.props.onClickLink,
-          onClickHashtag: this.props.onClickHashtag,
-          onHoverLink: this.props.onHoverLink,
-        }),
-        new Strikethrough(),
-        new OrderedList(),
-        new History(),
-        new SmartText(),
-        new TrailingNode(),
-        new MarkdownPaste(),
-        new Keys({
-          onBlur: this.handleEditorBlur,
-          onFocus: this.handleEditorFocus,
-          onSave: this.handleSave,
-          onSaveAndExit: this.handleSaveAndExit,
-          onCancel: this.props.onCancel,
-        }),
-        new BlockMenuTrigger({
-          dictionary,
-          onOpen: this.handleOpenBlockMenu,
-          onClose: this.handleCloseBlockMenu,
-        }),
-        new Placeholder({
-          placeholder: this.props.placeholder,
-        }),
-        new MaxLength({
-          maxLength: this.props.maxLength,
+        ...[
+          new Doc(),
+          new Text(),
+          new HardBreak(),
+          new Paragraph(),
+          new Blockquote(),
+          new CodeBlock({
+            dictionary,
+            onShowToast: this.props.onShowToast,
+          }),
+          new CodeFence({
+            dictionary,
+            onShowToast: this.props.onShowToast,
+          }),
+          new CheckboxList(),
+          new CheckboxItem(),
+          new BulletList(),
+          new Embed(),
+          new ListItem(),
+          new Notice({
+            dictionary,
+          }),
+          new Heading({
+            dictionary,
+            onShowToast: this.props.onShowToast,
+            offset: this.props.headingsOffset,
+          }),
+          new HorizontalRule(),
+          new Image({
+            dictionary,
+            uploadImage: this.props.uploadImage,
+            onImageUploadStart: this.props.onImageUploadStart,
+            onImageUploadStop: this.props.onImageUploadStop,
+            onShowToast: this.props.onShowToast,
+          }),
+          new Table(),
+          new TableCell({
+            onSelectTable: this.handleSelectTable,
+            onSelectRow: this.handleSelectRow,
+          }),
+          new TableHeadCell({
+            onSelectColumn: this.handleSelectColumn,
+          }),
+          new TableRow(),
+          new Bold(),
+          new Code(),
+          new Highlight(),
+          new Italic(),
+          new TemplatePlaceholder(),
+          new Underline(),
+          new Link({
+            onKeyboardShortcut: this.handleOpenLinkMenu,
+            onClickLink: this.props.onClickLink,
+            onClickHashtag: this.props.onClickHashtag,
+            onHoverLink: this.props.onHoverLink,
+          }),
+          new Strikethrough(),
+          new OrderedList(),
+          new History(),
+          new SmartText(),
+          new TrailingNode(),
+          new MarkdownPaste(),
+          new Keys({
+            onBlur: this.handleEditorBlur,
+            onFocus: this.handleEditorFocus,
+            onSave: this.handleSave,
+            onSaveAndExit: this.handleSaveAndExit,
+            onCancel: this.props.onCancel,
+          }),
+          new BlockMenuTrigger({
+            dictionary,
+            onOpen: this.handleOpenBlockMenu,
+            onClose: this.handleCloseBlockMenu,
+          }),
+          new Placeholder({
+            placeholder: this.props.placeholder,
+          }),
+          new MaxLength({
+            maxLength: this.props.maxLength,
+          }),
+        ].filter(extension => {
+          // Optionaly disable extensions
+          if (this.props.disableExtensions) {
+            return !this.props.disableExtensions.includes(extension.name);
+          }
+          return true;
         }),
         ...this.props.extensions,
       ],

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -370,7 +370,9 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
         ].filter(extension => {
           // Optionaly disable extensions
           if (this.props.disableExtensions) {
-            return !this.props.disableExtensions.includes(extension.name);
+            return !(this.props.disableExtensions as string[]).includes(
+              extension.name
+            );
           }
           return true;
         }),

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -82,7 +82,35 @@ export type Props = {
   defaultValue: string;
   placeholder: string;
   extensions: Extension[];
-  disableExtensions?: string[];
+  disableExtensions?: (
+    | "strong"
+    | "code_inline"
+    | "highlight"
+    | "em"
+    | "link"
+    | "placeholder"
+    | "strikethrough"
+    | "underline"
+    | "blockquote"
+    | "bullet_list"
+    | "checkbox_item"
+    | "checkbox_list"
+    | "code_block"
+    | "code_fence"
+    | "embed"
+    | "br"
+    | "heading"
+    | "hr"
+    | "image"
+    | "list_item"
+    | "container_notice"
+    | "ordered_list"
+    | "paragraph"
+    | "table"
+    | "td"
+    | "th"
+    | "tr"
+  )[];
   autoFocus?: boolean;
   readOnly?: boolean;
   readOnlyWriteCheckboxes?: boolean;

--- a/src/stories/index.stories.tsx
+++ b/src/stories/index.stories.tsx
@@ -16,6 +16,10 @@ export default {
     onShowToast: { action: "toast" },
     onFocus: { action: "focused" },
     onBlur: { action: "blurred" },
+    disableExtensions: { control: "array" },
+  },
+  args: {
+    disableExtensions: ["strong"],
   },
 } as Meta;
 

--- a/src/stories/index.stories.tsx
+++ b/src/stories/index.stories.tsx
@@ -19,7 +19,7 @@ export default {
     disableExtensions: { control: "array" },
   },
   args: {
-    disableExtensions: ["strong"],
+    disableExtensions: [],
   },
 } as Meta;
 


### PR DESCRIPTION
Another attempt at disabling extensions, related to #312 

- in `BlockMenu` and `SelectionToolbar` disable items with no matching commands (provided by `ExtensionManager`)
- filter extensions used to build `ExtensionManager` based on optional prop `disableExtensions?: string[]`
- ⚠️ any extension can be disabled, even `Doc` or `Text`, but hey, careful what you wish for
- I tried to keep changes to a minimum and avoid disruptive changes. We could make it more user-friendly by typing the prop, but it would require some refactor of typings