### PR TITLE
feat: add theme variables for selected block item icon and text

### DIFF
--- a/src/components/BlockMenuItem.tsx
+++ b/src/components/BlockMenuItem.tsx
@@ -47,7 +47,11 @@ function BlockMenuItem({
       onClick={disabled ? undefined : onClick}
       ref={ref}
     >
-      <Icon color={selected ? theme.black : undefined} />
+      <Icon
+        color={
+          selected ? theme.blockToolbarIconSelected : theme.blockToolbarIcon
+        }
+      />
       &nbsp;&nbsp;{title}
       <Shortcut>{shortcut}</Shortcut>
     </MenuItem>
@@ -69,7 +73,9 @@ const MenuItem = styled.button<{
   border: none;
   opacity: ${props => (props.disabled ? ".5" : "1")};
   color: ${props =>
-    props.selected ? props.theme.black : props.theme.blockToolbarText};
+    props.selected
+      ? props.theme.blockToolbarTextSelected
+      : props.theme.blockToolbarText};
   background: ${props =>
     props.selected ? props.theme.blockToolbarTrigger : "none"};
   padding: 0 16px;
@@ -77,7 +83,7 @@ const MenuItem = styled.button<{
 
   &:hover,
   &:active {
-    color: ${props => props.theme.black};
+    color: ${props => props.theme.blockToolbarTextSelected};
     background: ${props =>
       props.selected
         ? props.theme.blockToolbarTrigger

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -48,7 +48,10 @@ export const base = {
   blockToolbarTrigger: colors.greyMid,
   blockToolbarTriggerIcon: colors.white,
   blockToolbarItem: colors.almostBlack,
+  blockToolbarIcon: undefined,
+  blockToolbarIconSelected: colors.black,
   blockToolbarText: colors.almostBlack,
+  blockToolbarTextSelected: colors.black,
   blockToolbarHoverBackground: colors.greyLight,
   blockToolbarDivider: colors.greyMid,
 


### PR DESCRIPTION
Currently the selected menu block item icon and text color is hard coded to be black. This adds a theme variable for both the the icon color and text color.

![rte_block](https://user-images.githubusercontent.com/11680844/116828705-fbd4b580-ab65-11eb-9ca5-99f5cc7e3e57.png)
