### PR TITLE
fix: Improve `isUrl()` by adding RegExp

### DIFF
--- a/src/lib/isUrl.ts
+++ b/src/lib/isUrl.ts
@@ -3,7 +3,10 @@ export default function isUrl(text: string) {
     return false;
   }
 
-  const urlRegExp: RegExp = /(mailto:[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)|(((?:https?)|(?:ftp)):\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})/;
-  
-  return urlRegExp.test(text)
+  try {
+    const url = new URL(text);
+    return url.hostname !== "";
+  } catch (err) {
+    return false;
+  }
 }

--- a/src/lib/isUrl.ts
+++ b/src/lib/isUrl.ts
@@ -3,10 +3,7 @@ export default function isUrl(text: string) {
     return false;
   }
 
-  try {
-    new URL(text);
-    return true;
-  } catch (err) {
-    return false;
-  }
+  const urlRegExp: RegExp = /(mailto:[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)|(((?:https?)|(?:ftp)):\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})/;
+  
+  return urlRegExp.test(text)
 }


### PR DESCRIPTION
Improved `isURL` utility function by adding RegExp that processes `mailto:`, `http://`, `https://`, `ftp://` patterns to prevent some random strings as `abc:xyz some text` to be treated as real URL and a link.

Closes #440  