### PR TITLE
fix: removes image flickering after upload

### DIFF
--- a/src/commands/insertFiles.ts
+++ b/src/commands/insertFiles.ts
@@ -61,11 +61,15 @@ const insertFiles = function(view, event, pos, files, options) {
 
         // otherwise, insert it at the placeholder's position, and remove
         // the placeholder itself
-        const transaction = view.state.tr
-          .replaceWith(pos, pos, schema.nodes.image.create({ src }))
-          .setMeta(uploadPlaceholderPlugin, { remove: { id } });
+        const newImg = new Image();
+        newImg.onload = () => {
+          const transaction = view.state.tr
+            .replaceWith(pos, pos, schema.nodes.image.create({ src }))
+            .setMeta(uploadPlaceholderPlugin, { remove: { id } });
 
-        view.dispatch(transaction);
+          view.dispatch(transaction);
+        };
+        newImg.src = src;
       })
       .catch(error => {
         console.error(error);

--- a/src/commands/insertFiles.ts
+++ b/src/commands/insertFiles.ts
@@ -62,6 +62,7 @@ const insertFiles = function(view, event, pos, files, options) {
         // otherwise, insert it at the placeholder's position, and remove
         // the placeholder itself
         const newImg = new Image();
+
         newImg.onload = () => {
           const transaction = view.state.tr
             .replaceWith(pos, pos, schema.nodes.image.create({ src }))
@@ -69,6 +70,11 @@ const insertFiles = function(view, event, pos, files, options) {
 
           view.dispatch(transaction);
         };
+
+        newImg.onerror = error => {
+          throw error;
+        };
+
         newImg.src = src;
       })
       .catch(error => {


### PR DESCRIPTION
I noticed that after uploading an image there is a flicker when the in memory image is replaced by the remote image. To fix this I preloaded the remote image before the replace.

With image flickering:

https://user-images.githubusercontent.com/1238663/117144216-0e2e3980-ad88-11eb-9204-3cf7c4af1fdc.mp4

Without image flickering:

https://user-images.githubusercontent.com/1238663/117144400-4170c880-ad88-11eb-8e0e-57c516fcf393.mp4