### PR TITLE
fix: Allow intraword underscores

### DIFF
--- a/src/marks/Italic.ts
+++ b/src/marks/Italic.ts
@@ -20,7 +20,7 @@ export default class Italic extends Mark {
 
   inputRules({ type }) {
     return [
-      markInputRule(/(?:^|[^_])(_([^_]+)_)$/, type),
+      markInputRule(/(?:^|[\s])(_([^_]+)_)$/, type),
       markInputRule(/(?:^|[^*])(\*([^*]+)\*)$/, type),
     ];
   }


### PR DESCRIPTION
Fixes issue #452.

As I've said on the related issue, this doesn't make this Markdown parser _totally_ CommonMark-compliant, but it should solve a relatively common pain point writing underscore-heavy content.

I've only changed the `_` behaviour because intraword `*` _are_ allowed in Markdown.