### PR TITLE
feat: Remember previous code block language as default

### DIFF
--- a/src/nodes/CodeFence.ts
+++ b/src/nodes/CodeFence.ts
@@ -23,6 +23,8 @@ import isInCode from "../queries/isInCode";
 import Node from "./Node";
 import { ToastType } from "../types";
 
+const PERSISTENCE_KEY = "rme-code-language";
+
 [
   bash,
   css,
@@ -106,7 +108,8 @@ export default class CodeFence extends Node {
   }
 
   commands({ type }) {
-    return () => setBlockType(type);
+    return () =>
+      setBlockType(type, { language: localStorage?.getItem(PERSISTENCE_KEY) });
   }
 
   keys({ type }) {
@@ -157,10 +160,13 @@ export default class CodeFence extends Node {
     const result = view.posAtCoords({ top, left });
 
     if (result) {
+      const language = element.value;
       const transaction = tr.setNodeMarkup(result.inside, undefined, {
-        language: element.value,
+        language,
       });
       view.dispatch(transaction);
+
+      localStorage?.setItem(PERSISTENCE_KEY, language);
     }
   };
 

--- a/src/nodes/CodeFence.ts
+++ b/src/nodes/CodeFence.ts
@@ -24,6 +24,7 @@ import Node from "./Node";
 import { ToastType } from "../types";
 
 const PERSISTENCE_KEY = "rme-code-language";
+const DEFAULT_LANGUAGE = "javascript";
 
 [
   bash,
@@ -57,7 +58,7 @@ export default class CodeFence extends Node {
     return {
       attrs: {
         language: {
-          default: "javascript",
+          default: DEFAULT_LANGUAGE,
         },
       },
       content: "text*",
@@ -109,7 +110,9 @@ export default class CodeFence extends Node {
 
   commands({ type }) {
     return () =>
-      setBlockType(type, { language: localStorage?.getItem(PERSISTENCE_KEY) });
+      setBlockType(type, {
+        language: localStorage?.getItem(PERSISTENCE_KEY) || DEFAULT_LANGUAGE,
+      });
   }
 
   keys({ type }) {


### PR DESCRIPTION
Simple quality of life improvement remembers the last code language used on the local machine instead of always defaulting to javascript (as much as we love it)

closes outline/outline#2067