### PR TITLE
feat: RTL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ With `dark` set to `true` the editor will use a default dark theme that's includ
 *Default: `auto`*
 
 Controls direction of the document. Possible values are:
-- `ltr`: Editor components are optimized for LTR documents and the content is explicitly marked as LTR.
-- `rtl`: Editor components are optimized for RTL documents and the content is explicitly marked as RTL.
-- `auto`: Editor components are optimized for LTR documents but the browser decides the direction of the content.
+- `ltr`: Editor layout is optimized for LTR documents and the content is explicitly marked as LTR.
+- `rtl`: Editor layout is optimized for RTL documents and the content is explicitly marked as RTL.
+- `auto`: Editor layout is decided by the browser based on document content.
 
 #### `tooltip`
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ With `readOnly` set to `false` the editor is optimized for composition. When `tr
 
 With `readOnlyWriteCheckboxes` set to `true` checkboxes can still be checked or unchecked as a special case while `readOnly` is set to `true` and the editor is otherwise unable to be edited.
 
+#### `rtl`
+
+With `rtl` set to `true`, the editor is enhanced for viewing and editing documents in RTL languages.
+
 #### `autoFocus`
 
 When set `true` together with `readOnly` set to `false`, focus at the end of the

--- a/README.md
+++ b/README.md
@@ -65,10 +65,6 @@ With `readOnly` set to `false` the editor is optimized for composition. When `tr
 
 With `readOnlyWriteCheckboxes` set to `true` checkboxes can still be checked or unchecked as a special case while `readOnly` is set to `true` and the editor is otherwise unable to be edited.
 
-#### `rtl`
-
-With `rtl` set to `true`, the editor is enhanced for viewing and editing documents in RTL languages.
-
 #### `autoFocus`
 
 When set `true` together with `readOnly` set to `false`, focus at the end of the
@@ -93,6 +89,15 @@ Allows overriding the inbuilt copy dictionary, for example to internationalize t
 #### `dark`
 
 With `dark` set to `true` the editor will use a default dark theme that's included. See the [source here](/src/theme.ts).
+
+#### `dir`
+
+*Default: `auto`*
+
+Controls direction of the document. Possible values are:
+- `ltr`: Editor components are optimized for LTR documents and the content is explicitly marked as LTR.
+- `rtl`: Editor components are optimized for RTL documents and the content is explicitly marked as RTL.
+- `auto`: Editor components are optimized for LTR documents but the browser decides the direction of the content.
 
 #### `tooltip`
 

--- a/src/components/BlockMenu.tsx
+++ b/src/components/BlockMenu.tsx
@@ -360,9 +360,9 @@ class BlockMenu extends React.Component<Props, State> {
     const { top, bottom } = paragraph.node.getBoundingClientRect();
     const margin = 24;
 
-    let leftPos = left + window.scrollX
+    let leftPos = left + window.scrollX;
     if (props.rtl && ref) {
-      leftPos -= ref.scrollWidth
+      leftPos -= ref.scrollWidth;
     }
 
     if (startPos.top - offsetHeight > margin) {

--- a/src/components/BlockMenu.tsx
+++ b/src/components/BlockMenu.tsx
@@ -357,12 +357,12 @@ class BlockMenu extends React.Component<Props, State> {
     }
 
     const { left } = this.caretPosition;
-    const { top, bottom } = paragraph.node.getBoundingClientRect();
+    const { top, bottom, right } = paragraph.node.getBoundingClientRect();
     const margin = 24;
 
     let leftPos = left + window.scrollX;
     if (props.rtl && ref) {
-      leftPos -= ref.scrollWidth;
+      leftPos = right - ref.scrollWidth;
     }
 
     if (startPos.top - offsetHeight > margin) {

--- a/src/components/BlockMenu.tsx
+++ b/src/components/BlockMenu.tsx
@@ -23,6 +23,7 @@ const defaultPosition = {
 };
 
 type Props = {
+  rtl: boolean;
   isActive: boolean;
   commands: Record<string, any>;
   dictionary: typeof baseDictionary;
@@ -359,16 +360,21 @@ class BlockMenu extends React.Component<Props, State> {
     const { top, bottom } = paragraph.node.getBoundingClientRect();
     const margin = 24;
 
+    let leftPos = left + window.scrollX
+    if (props.rtl && ref) {
+      leftPos -= ref.scrollWidth
+    }
+
     if (startPos.top - offsetHeight > margin) {
       return {
-        left: left + window.scrollX,
+        left: leftPos,
         top: undefined,
         bottom: window.innerHeight - top - window.scrollY,
         isAbove: false,
       };
     } else {
       return {
-        left: left + window.scrollX,
+        left: leftPos,
         top: bottom + window.scrollY,
         bottom: undefined,
         isAbove: true,

--- a/src/components/SelectionToolbar.tsx
+++ b/src/components/SelectionToolbar.tsx
@@ -24,6 +24,7 @@ import baseDictionary from "../dictionary";
 type Props = {
   dictionary: typeof baseDictionary;
   tooltip: typeof React.Component | React.FC<any>;
+  rtl: boolean;
   isTemplate: boolean;
   commands: Record<string, any>;
   onOpen: () => void;
@@ -121,7 +122,7 @@ export default class SelectionToolbar extends React.Component<Props> {
   };
 
   render() {
-    const { dictionary, onCreateLink, isTemplate, ...rest } = this.props;
+    const { dictionary, onCreateLink, isTemplate, rtl, ...rest } = this.props;
     const { view } = rest;
     const { state } = view;
     const { selection }: { selection: any } = state;
@@ -145,7 +146,7 @@ export default class SelectionToolbar extends React.Component<Props> {
     if (isTableSelection) {
       items = getTableMenuItems(dictionary);
     } else if (colIndex !== undefined) {
-      items = getTableColMenuItems(state, colIndex, dictionary);
+      items = getTableColMenuItems(state, colIndex, rtl, dictionary);
     } else if (rowIndex !== undefined) {
       items = getTableRowMenuItems(state, rowIndex, dictionary);
     } else if (isImageSelection) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -87,6 +87,7 @@ export type Props = {
   readOnlyWriteCheckboxes?: boolean;
   dictionary?: Partial<typeof baseDictionary>;
   dark?: boolean;
+  rtl?: boolean;
   theme?: typeof theme;
   template?: boolean;
   headingsOffset?: number;
@@ -628,6 +629,7 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
 
   render = () => {
     const {
+      rtl,
       readOnly,
       readOnlyWriteCheckboxes,
       style,
@@ -644,11 +646,13 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
         className={className}
         align="flex-start"
         justify="center"
+        dir={rtl ? "rtl" : "ltr"}
         column
       >
         <ThemeProvider theme={this.theme()}>
           <React.Fragment>
             <StyledEditor
+              rtl={rtl === true}
               readOnly={readOnly}
               readOnlyWriteCheckboxes={readOnlyWriteCheckboxes}
               ref={ref => (this.element = ref)}
@@ -659,6 +663,7 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
                   view={this.view}
                   dictionary={dictionary}
                   commands={this.commands}
+                  rtl={rtl === true}
                   isTemplate={this.props.template === true}
                   onOpen={this.handleOpenSelectionMenu}
                   onClose={this.handleCloseSelectionMenu}
@@ -682,6 +687,7 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
                   view={this.view}
                   commands={this.commands}
                   dictionary={dictionary}
+                  rtl={rtl === true}
                   isActive={this.state.blockMenuOpen}
                   search={this.state.blockMenuSearch}
                   onClose={this.handleCloseBlockMenu}
@@ -702,6 +708,7 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
 }
 
 const StyledEditor = styled("div")<{
+  rtl: boolean;
   readOnly?: boolean;
   readOnlyWriteCheckboxes?: boolean;
 }>`
@@ -795,8 +802,8 @@ const StyledEditor = styled("div")<{
   li.ProseMirror-selectednode:after {
     content: "";
     position: absolute;
-    left: -32px;
-    right: -2px;
+    left: ${props => (props.rtl ? "-2px" : "-32px")};
+    right: ${props => (props.rtl ? "-32px" : "-2px")};
     top: -2px;
     bottom: -2px;
     border: 2px solid ${props => props.theme.selected};
@@ -828,7 +835,7 @@ const StyledEditor = styled("div")<{
       color: ${props => props.theme.textSecondary};
       font-size: 13px;
       line-height: 0;
-      margin-left: -24px;
+      margin-${props => (props.rtl ? "right" : "left")}: -24px;
       width: 24px;
     }
 
@@ -883,7 +890,7 @@ const StyledEditor = styled("div")<{
   }
 
   .with-emoji {
-    margin-left: -1em;
+    margin-${props => (props.rtl ? "right" : "left")}: -1em;
   }
 
   .heading-anchor {
@@ -894,13 +901,13 @@ const StyledEditor = styled("div")<{
     background: none;
     border: 0;
     outline: none;
-    padding: 2px 12px 2px 4px;
+    padding: ${props => (props.rtl ? "2px 2px 12px 4px" : "2px 12px 2px 4px")};
     margin: 0;
     transition: opacity 100ms ease-in-out;
     font-family: ${props => props.theme.fontFamilyMono};
     font-size: 22px;
     line-height: 0;
-    margin-left: -24px;
+    margin-${props => (props.rtl ? "right" : "left")}: -24px;
     width: 24px;
 
     &:focus,
@@ -951,7 +958,7 @@ const StyledEditor = styled("div")<{
     width: 24px;
     height: 24px;
     align-self: flex-start;
-    margin-right: 4px;
+    margin-${props => (props.rtl ? "left" : "right")}: 4px;
     position: relative;
     top: 1px;
   }
@@ -987,7 +994,7 @@ const StyledEditor = styled("div")<{
       width: 3px;
       border-radius: 1px;
       position: absolute;
-      margin-left: -16px;
+      margin-${props => (props.rtl ? "right" : "left")}: -16px;
       top: 0;
       bottom: 0;
       background: ${props => props.theme.quote};
@@ -1026,12 +1033,12 @@ const StyledEditor = styled("div")<{
 
   ul,
   ol {
-    margin: 0 0.1em 0 -26px;
-    padding: 0 0 0 44px;
+    margin: ${props => (props.rtl ? "0 -26px 0 0.1em" : "0 0.1em 0 -26px")};
+    padding: ${props => (props.rtl ? "0 44px 0 0" : "0 0 0 44px")};
 
     ul,
     ol {
-      margin-right: -24px;
+      margin-${props => (props.rtl ? "left" : "right")}: -24px;
     }
   }
 
@@ -1046,7 +1053,7 @@ const StyledEditor = styled("div")<{
   ul.checkbox_list {
     list-style: none;
     padding: 0;
-    margin: 0 0 0 -24px;
+    margin: ${props => (props.rtl ? "0 -24px 0 0" : "0 0 0 -24px")};
   }
 
   ul li,
@@ -1065,7 +1072,7 @@ const StyledEditor = styled("div")<{
 
   ul.checkbox_list li {
     display: flex;
-    padding-left: 24px;
+    padding-${props => (props.rtl ? "right" : "left")}: 24px;
   }
 
   ul.checkbox_list li.checked > div > p {
@@ -1082,7 +1089,7 @@ const StyledEditor = styled("div")<{
     width: 24px;
     height: 24px;
     position: absolute;
-    left: -40px;
+    ${props => (props.rtl ? "right" : "left")}: -40px;
     top: 2px;
     opacity: 0;
     transition: opacity 200ms ease-in-out;
@@ -1099,7 +1106,7 @@ const StyledEditor = styled("div")<{
   }
 
   ul.checkbox_list li::before {
-    left: 0;
+    ${props => (props.rtl ? "right" : "left")}: 0;
   }
 
   ul.checkbox_list li input {
@@ -1107,7 +1114,7 @@ const StyledEditor = styled("div")<{
       props.readOnly && !props.readOnlyWriteCheckboxes ? "none" : "initial"};
     opacity: ${props =>
       props.readOnly && !props.readOnlyWriteCheckboxes ? 0.75 : 1};
-    margin: 0.5em 0.5em 0 0;
+    margin: ${props => (props.rtl ? "0.5em 0 0 0.5em" : "0.5em 0.5em 0 0")};
     width: 14px;
     height: 14px;
   }
@@ -1175,7 +1182,7 @@ const StyledEditor = styled("div")<{
       padding: 2px;
       z-index: 1;
       top: 4px;
-      right: 4px;
+      ${props => (props.rtl ? "left" : "right")}: 4px;
     }
 
     button {
@@ -1358,7 +1365,7 @@ const StyledEditor = styled("div")<{
       border: 1px solid ${props => props.theme.tableDivider};
       position: relative;
       padding: 4px 8px;
-      text-align: left;
+      text-align: ${props => (props.rtl ? "right" : "left")};
       min-width: 100px;
     }
 
@@ -1381,7 +1388,7 @@ const StyledEditor = styled("div")<{
         cursor: pointer;
         position: absolute;
         top: -16px;
-        left: 0;
+        ${props => (props.rtl ? "right" : "left")}: 0;
         width: 100%;
         height: 12px;
         background: ${props => props.theme.tableDivider};
@@ -1408,12 +1415,12 @@ const StyledEditor = styled("div")<{
         content: "";
         cursor: pointer;
         position: absolute;
-        left: -16px;
+        ${props => (props.rtl ? "right" : "left")}: -16px;
         top: 0;
         height: 100%;
         width: 12px;
         background: ${props => props.theme.tableDivider};
-        border-right: 3px solid ${props => props.theme.background};
+        border-${props => (props.rtl ? "left" : "right")}: 3px solid ${props => props.theme.background};
         display: ${props => (props.readOnly ? "none" : "block")};
       }
 
@@ -1442,7 +1449,7 @@ const StyledEditor = styled("div")<{
         border: 2px solid ${props => props.theme.background};
         position: absolute;
         top: -18px;
-        left: -18px;
+        ${props => (props.rtl ? "right" : "left")}: -18px;
         display: ${props => (props.readOnly ? "none" : "block")};
       }
 
@@ -1490,10 +1497,10 @@ const StyledEditor = styled("div")<{
   .scrollable {
     overflow-y: hidden;
     overflow-x: auto;
-    padding-left: 1em;
-    margin-left: -1em;
-    border-left: 1px solid transparent;
-    border-right: 1px solid transparent;
+    padding-${props => (props.rtl ? "right" : "left")}: 1em;
+    margin-${props => (props.rtl ? "right" : "left")}: -1em;
+    border-${props => (props.rtl ? "right" : "left")}: 1px solid transparent;
+    border-${props => (props.rtl ? "left" : "right")}: 1px solid transparent;
     transition: border 250ms ease-in-out 0s;
   }
 
@@ -1501,11 +1508,11 @@ const StyledEditor = styled("div")<{
     position: absolute;
     top: 0;
     bottom: 0;
-    left: -1em;
+    ${props => (props.rtl ? "right" : "left")}: -1em;
     width: 16px;
     transition: box-shadow 250ms ease-in-out;
     border: 0px solid transparent;
-    border-left-width: 1em;
+    border-${props => (props.rtl ? "right" : "left")}-width: 1em;
     pointer-events: none;
 
     &.left {
@@ -1533,7 +1540,7 @@ const StyledEditor = styled("div")<{
     border: 0;
     padding: 0;
     margin-top: 1px;
-    margin-left: -24px;
+    margin-${props => (props.rtl ? "right" : "left")}: -24px;
 
     &:hover,
     &:focus {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -639,7 +639,7 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
       onKeyDown,
     } = this.props;
     const dictionary = this.dictionary(this.props.dictionary);
-    const isRTL = dir === 'rtl';
+    const isRTL = dir === "rtl";
     return (
       <Flex
         onKeyDown={onKeyDown}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -719,7 +719,6 @@ const StyledEditor = styled("div")<{
   font-size: 1em;
   line-height: 1.7em;
   width: 100%;
-
   .ProseMirror {
     position: relative;
     outline: none;
@@ -1021,6 +1020,7 @@ const StyledEditor = styled("div")<{
 
   p {
     margin: 0;
+    unicode-bidi: plaintext;
   }
 
   a {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -87,7 +87,7 @@ export type Props = {
   readOnlyWriteCheckboxes?: boolean;
   dictionary?: Partial<typeof baseDictionary>;
   dark?: boolean;
-  rtl?: boolean;
+  dir?: string;
   theme?: typeof theme;
   template?: boolean;
   headingsOffset?: number;
@@ -132,6 +132,7 @@ type Step = {
 class RichMarkdownEditor extends React.PureComponent<Props, State> {
   static defaultProps = {
     defaultValue: "",
+    dir: "auto",
     placeholder: "Write something nice…",
     onImageUploadStart: () => {
       // no default behavior
@@ -629,7 +630,7 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
 
   render = () => {
     const {
-      rtl,
+      dir,
       readOnly,
       readOnlyWriteCheckboxes,
       style,
@@ -638,7 +639,7 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
       onKeyDown,
     } = this.props;
     const dictionary = this.dictionary(this.props.dictionary);
-
+    const isRTL = dir === 'rtl';
     return (
       <Flex
         onKeyDown={onKeyDown}
@@ -646,13 +647,13 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
         className={className}
         align="flex-start"
         justify="center"
-        dir={rtl ? "rtl" : "ltr"}
+        dir={dir}
         column
       >
         <ThemeProvider theme={this.theme()}>
           <React.Fragment>
             <StyledEditor
-              rtl={rtl === true}
+              rtl={isRTL}
               readOnly={readOnly}
               readOnlyWriteCheckboxes={readOnlyWriteCheckboxes}
               ref={ref => (this.element = ref)}
@@ -663,7 +664,7 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
                   view={this.view}
                   dictionary={dictionary}
                   commands={this.commands}
-                  rtl={rtl === true}
+                  rtl={isRTL}
                   isTemplate={this.props.template === true}
                   onOpen={this.handleOpenSelectionMenu}
                   onClose={this.handleCloseSelectionMenu}
@@ -687,7 +688,7 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
                   view={this.view}
                   commands={this.commands}
                   dictionary={dictionary}
-                  rtl={rtl === true}
+                  rtl={isRTL}
                   isActive={this.state.blockMenuOpen}
                   search={this.state.blockMenuSearch}
                   onClose={this.handleCloseBlockMenu}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -118,6 +118,7 @@ export type Props = {
 };
 
 type State = {
+  isRTL: boolean;
   isEditorFocused: boolean;
   selectionMenuOpen: boolean;
   blockMenuOpen: boolean;
@@ -149,6 +150,7 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
   };
 
   state = {
+    isRTL: false,
     isEditorFocused: false,
     selectionMenuOpen: false,
     blockMenuOpen: false,
@@ -180,6 +182,8 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
       this.scrollToAnchor(this.props.scrollTo);
     }
 
+    this.calculateDir();
+
     if (this.props.readOnly) return;
 
     if (this.props.autoFocus) {
@@ -210,6 +214,10 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
     // is set to true
     if (prevProps.readOnly && !this.props.readOnly && this.props.autoFocus) {
       this.focusAtEnd();
+    }
+
+    if (prevProps.dir !== this.props.dir) {
+      this.calculateDir();
     }
 
     if (
@@ -475,6 +483,8 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
           this.handleChange();
         }
 
+        this.calculateDir();
+
         // Because Prosemirror and React are not linked we must tell React that
         // a render is needed whenever the Prosemirror state changes.
         this.forceUpdate();
@@ -500,6 +510,18 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
       console.warn(`Attempted to scroll to invalid hash: ${hash}`, err);
     }
   }
+
+  calculateDir = () => {
+    if (!this.element) return;
+
+    const isRTL =
+      this.props.dir === "rtl" ||
+      getComputedStyle(this.element).direction === "rtl";
+
+    if (this.state.isRTL !== isRTL) {
+      this.setState({ isRTL });
+    }
+  };
 
   value = (): string => {
     return this.serializer.serialize(this.view.state.doc);
@@ -638,8 +660,9 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
       className,
       onKeyDown,
     } = this.props;
+    const { isRTL } = this.state;
     const dictionary = this.dictionary(this.props.dictionary);
-    const isRTL = dir === "rtl";
+
     return (
       <Flex
         onKeyDown={onKeyDown}
@@ -653,6 +676,7 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
         <ThemeProvider theme={this.theme()}>
           <React.Fragment>
             <StyledEditor
+              dir={dir}
               rtl={isRTL}
               readOnly={readOnly}
               readOnlyWriteCheckboxes={readOnlyWriteCheckboxes}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1045,7 +1045,6 @@ const StyledEditor = styled("div")<{
 
   p {
     margin: 0;
-    unicode-bidi: plaintext;
   }
 
   a {
@@ -1207,7 +1206,20 @@ const StyledEditor = styled("div")<{
       padding: 2px;
       z-index: 1;
       top: 4px;
-      ${props => (props.rtl ? "left" : "right")}: 4px;
+    }
+
+    &.code-block {
+      select,
+      button {
+        right: 4px;
+      }
+    }
+
+    &.notice-block {
+      select,
+      button {
+        ${props => (props.rtl ? "left" : "right")}: 4px;
+      }
     }
 
     button {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1420,7 +1420,8 @@ const StyledEditor = styled("div")<{
         height: 100%;
         width: 12px;
         background: ${props => props.theme.tableDivider};
-        border-${props => (props.rtl ? "left" : "right")}: 3px solid ${props => props.theme.background};
+        border-${props => (props.rtl ? "left" : "right")}: 3px solid;
+        border-color: ${props => props.theme.background};
         display: ${props => (props.readOnly ? "none" : "block")};
       }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1400,10 +1400,10 @@ const StyledEditor = styled("div")<{
         background: ${props => props.theme.text};
       }
       &.first::after {
-        border-top-left-radius: 3px;
+        border-top-${props => (props.rtl ? "right" : "left")}-radius: 3px;
       }
       &.last::after {
-        border-top-right-radius: 3px;
+        border-top-${props => (props.rtl ? "left" : "right")}-radius: 3px;
       }
       &.selected::after {
         background: ${props => props.theme.tableSelected};
@@ -1429,10 +1429,10 @@ const StyledEditor = styled("div")<{
         background: ${props => props.theme.text};
       }
       &.first::after {
-        border-top-left-radius: 3px;
+        border-top-${props => (props.rtl ? "right" : "left")}-radius: 3px;
       }
       &.last::after {
-        border-bottom-left-radius: 3px;
+        border-bottom-${props => (props.rtl ? "right" : "left")}-radius: 3px;
       }
       &.selected::after {
         background: ${props => props.theme.tableSelected};

--- a/src/menus/tableCol.tsx
+++ b/src/menus/tableCol.tsx
@@ -14,6 +14,7 @@ import baseDictionary from "../dictionary";
 export default function tableColMenuItems(
   state: EditorState,
   index: number,
+  rtl: boolean,
   dictionary: typeof baseDictionary
 ): MenuItem[] {
   const { schema } = state;
@@ -56,14 +57,14 @@ export default function tableColMenuItems(
       name: "separator",
     },
     {
-      name: "addColumnBefore",
-      tooltip: dictionary.addColumnBefore,
+      name: rtl ? "addColumnAfter" : "addColumnBefore",
+      tooltip: rtl ? dictionary.addColumnAfter : dictionary.addColumnBefore,
       icon: InsertLeftIcon,
       active: () => false,
     },
     {
-      name: "addColumnAfter",
-      tooltip: dictionary.addColumnAfter,
+      name: rtl ? "addColumnBefore" : "addColumnAfter",
+      tooltip: rtl ? dictionary.addColumnBefore : dictionary.addColumnAfter,
       icon: InsertRightIcon,
       active: () => false,
     },

--- a/src/stories/index.stories.tsx
+++ b/src/stories/index.stories.tsx
@@ -207,3 +207,16 @@ Dark.args = {
 
 There's a customizable dark theme too`,
 };
+
+
+export const RTL = Template.bind({});
+RTL.args = {
+  rtl: true,
+  defaultValue: `# خوش آمدید
+
+متن نمونه برای نمایش پشتیبانی از زبان‌های RTL نظیر فارسی، عربی، عبری و ...
+
+\\
+- [x] آیتم اول
+- [ ] آیتم دوم`,
+};

--- a/src/stories/index.stories.tsx
+++ b/src/stories/index.stories.tsx
@@ -208,7 +208,6 @@ Dark.args = {
 There's a customizable dark theme too`,
 };
 
-
 export const RTL = Template.bind({});
 RTL.args = {
   rtl: true,

--- a/src/stories/index.stories.tsx
+++ b/src/stories/index.stories.tsx
@@ -210,7 +210,7 @@ There's a customizable dark theme too`,
 
 export const RTL = Template.bind({});
 RTL.args = {
-  rtl: true,
+  dir: "rtl",
   defaultValue: `# خوش آمدید
 
 متن نمونه برای نمایش پشتیبانی از زبان‌های RTL نظیر فارسی، عربی، عبری و ...


### PR DESCRIPTION
Enhances the editor to work with **RTL documents.** This is not a full fledged per-node direction support. It just allows the whole rendering to be compatible with the direction of the main, which should cover most of the use-cases for now. Should the need for per-paragraph direction override arise, we still need the elements of the editor to be rendered respective to the direction of the primary language, which means that this is a necessary steps towards that feature.

<img width="480" alt="Block menu is correctly positioned based on the document direction" src="https://user-images.githubusercontent.com/8026878/121511072-862df600-c9fd-11eb-868a-1e6ff3ce3fdd.png">

<img width="480" alt="Table controls and grips adjusted to respect document direction" src="https://user-images.githubusercontent.com/8026878/121511184-9e9e1080-c9fd-11eb-82b9-6e52e9de172e.png">

If this PR is accepted, it will be followed by another one for the **outline** app to bring RTL support to the platform. Some changes and tweaks to the API and the web app are required to fully fix the issues with RTL/mixed content presentation (which is already a work in progress).

Fixes outline/outline#2201