### PR TITLE
fix: Avoid re-download of image from remote source when clicking download button

### DIFF
--- a/src/components/FloatingToolbar.tsx
+++ b/src/components/FloatingToolbar.tsx
@@ -96,46 +96,49 @@ function usePosition({ menuRef, isSelectingText, props }) {
     const element = view.nodeDOM(selection.from);
 
     // Images are wrapped which impacts positioning - need to traverse through
-    // p > span > div.image
-    const imageElement = element.getElementsByTagName("img")[0];
-    const { left, top, width } = imageElement.getBoundingClientRect();
+    // p > span > div.image > img
+    const imageElement =
+      element.querySelector("img") || element.querySelector(".error");
+    if (imageElement) {
+      const { left, top, width } = imageElement.getBoundingClientRect();
 
-    return {
-      left: Math.round(left + width / 2 + window.scrollX - menuWidth / 2),
-      top: Math.round(top + window.scrollY - menuHeight),
-      offset: 0,
-      visible: true,
-    };
-  } else {
-    // calcluate the horizontal center of the selection
-    const halfSelection =
-      Math.abs(selectionBounds.right - selectionBounds.left) / 2;
-    const centerOfSelection = selectionBounds.left + halfSelection;
-
-    // position the menu so that it is centered over the selection except in
-    // the cases where it would extend off the edge of the screen. In these
-    // instances leave a margin
-    const margin = 12;
-    const left = Math.min(
-      window.innerWidth - menuWidth - margin,
-      Math.max(margin, centerOfSelection - menuWidth / 2)
-    );
-    const top = Math.min(
-      window.innerHeight - menuHeight - margin,
-      Math.max(margin, selectionBounds.top - menuHeight)
-    );
-
-    // if the menu has been offset to not extend offscreen then we should adjust
-    // the position of the triangle underneath to correctly point to the center
-    // of the selection still
-    const offset = left - (centerOfSelection - menuWidth / 2);
-    return {
-      left: Math.round(left + window.scrollX),
-      top: Math.round(top + window.scrollY),
-      offset: Math.round(offset),
-      visible: true,
-    };
+      return {
+        left: Math.round(left + width / 2 + window.scrollX - menuWidth / 2),
+        top: Math.round(top + window.scrollY - menuHeight),
+        offset: 0,
+        visible: true,
+      };
+    }
   }
+
+  // calcluate the horizontal center of the selection
+  const halfSelection =
+    Math.abs(selectionBounds.right - selectionBounds.left) / 2;
+  const centerOfSelection = selectionBounds.left + halfSelection;
+
+  // position the menu so that it is centered over the selection except in
+  // the cases where it would extend off the edge of the screen. In these
+  // instances leave a margin
+  const margin = 12;
+  const left = Math.min(
+    window.innerWidth - menuWidth - margin,
+    Math.max(margin, centerOfSelection - menuWidth / 2)
+  );
+  const top = Math.min(
+    window.innerHeight - menuHeight - margin,
+    Math.max(margin, selectionBounds.top - menuHeight)
+  );
+
+  // if the menu has been offset to not extend offscreen then we should adjust
+  // the position of the triangle underneath to correctly point to the center
+  // of the selection still
+  const offset = left - (centerOfSelection - menuWidth / 2);
+  return {
+    left: Math.round(left + window.scrollX),
+    top: Math.round(top + window.scrollY),
+    offset: Math.round(offset),
+    visible: true,
+  };
 }
 
 function FloatingToolbar(props) {

--- a/src/dictionary.ts
+++ b/src/dictionary.ts
@@ -32,6 +32,8 @@ export const base = {
   hr: "Divider",
   image: "Image",
   imageUploadError: "Sorry, an error occurred uploading the image",
+  imageDownloadError:
+    "Sorry, an error occurred downloading the image. Try refreshing the page?",
   info: "Info",
   infoNotice: "Info notice",
   link: "Link",

--- a/src/nodes/Image.tsx
+++ b/src/nodes/Image.tsx
@@ -87,33 +87,102 @@ const uploadPlugin = options =>
 const IMAGE_CLASSES = ["right-50", "left-50"];
 const getLayoutAndTitle = tokenTitle => {
   if (!tokenTitle) return {};
+
   if (IMAGE_CLASSES.includes(tokenTitle)) {
     return {
       layoutClass: tokenTitle,
     };
-  } else {
-    return {
-      title: tokenTitle,
-    };
   }
+
+  return {
+    title: tokenTitle,
+  };
 };
 
-const downloadImageNode = async node => {
-  const image = await fetch(node.attrs.src);
-  const imageBlob = await image.blob();
-  const imageURL = URL.createObjectURL(imageBlob);
-  const extension = imageBlob.type.split("/")[1];
-  const potentialName = node.attrs.alt || "image";
-
+const download = (imageUrl, fileName) => {
   // create a temporary link node and click it with our image data
   const link = document.createElement("a");
-  link.href = imageURL;
-  link.download = `${potentialName}.${extension}`;
+  link.href = imageUrl;
+  link.download = fileName;
   document.body.appendChild(link);
   link.click();
 
   // cleanup
   document.body.removeChild(link);
+};
+
+const ImageComponent = props => {
+  const [imageUrl, setImageUrl] = React.useState<string>();
+  const [imageExtension, setImageExtension] = React.useState<string>();
+  const { theme, isSelected, onSelect, onKeyDown, onBlur } = props;
+  const { alt, src, title, layoutClass } = props.node.attrs;
+  const className = layoutClass ? `image image-${layoutClass}` : "image";
+
+  React.useEffect(() => {
+    const download = async function() {
+      const image = await fetch(src);
+      const imageBlob = await image.blob();
+      const imageUrl = URL.createObjectURL(imageBlob);
+      const extension = imageBlob.type.split("/")[1];
+      setImageUrl(imageUrl);
+      setImageExtension(extension);
+    };
+
+    download();
+  }, [src]);
+
+  const handleDownload = React.useCallback(
+    event => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (!imageUrl) return;
+
+      const fileName = alt || "image";
+      download(imageUrl, `${fileName}.${imageExtension}`);
+    },
+    [alt, imageExtension]
+  );
+
+  if (!imageUrl) {
+    return null;
+  }
+
+  return (
+    <div contentEditable={false} className={className}>
+      <ImageWrapper
+        className={isSelected ? "ProseMirror-selectednode" : ""}
+        onClick={onSelect}
+      >
+        <Button>
+          <DownloadIcon color="currentColor" onClick={handleDownload} />
+        </Button>
+        <ImageZoom
+          image={{
+            src: imageUrl,
+            alt,
+            title,
+          }}
+          defaultStyles={{
+            overlay: {
+              backgroundColor: theme.background,
+            },
+          }}
+          shouldRespectMaxDimension
+        />
+      </ImageWrapper>
+      <Caption
+        onKeyDown={onKeyDown}
+        onBlur={onBlur}
+        className="caption"
+        tabIndex={-1}
+        role="textbox"
+        contentEditable
+        suppressContentEditableWarning
+      >
+        {alt}
+      </Caption>
+    </div>
+  );
 };
 
 export default class Image extends Node {
@@ -231,55 +300,14 @@ export default class Image extends Node {
     view.dispatch(transaction);
   };
 
-  handleDownload = ({ node }) => event => {
-    event.preventDefault();
-    event.stopPropagation();
-    downloadImageNode(node);
-  };
-
   component = props => {
-    const { theme, isSelected } = props;
-    const { alt, src, title, layoutClass } = props.node.attrs;
-    const className = layoutClass ? `image image-${layoutClass}` : "image";
-
     return (
-      <div contentEditable={false} className={className}>
-        <ImageWrapper
-          className={isSelected ? "ProseMirror-selectednode" : ""}
-          onClick={this.handleSelect(props)}
-        >
-          <Button>
-            <DownloadIcon
-              color="currentColor"
-              onClick={this.handleDownload(props)}
-            />
-          </Button>
-          <ImageZoom
-            image={{
-              src,
-              alt,
-              title,
-            }}
-            defaultStyles={{
-              overlay: {
-                backgroundColor: theme.background,
-              },
-            }}
-            shouldRespectMaxDimension
-          />
-        </ImageWrapper>
-        <Caption
-          onKeyDown={this.handleKeyDown(props)}
-          onBlur={this.handleBlur(props)}
-          className="caption"
-          tabIndex={-1}
-          role="textbox"
-          contentEditable
-          suppressContentEditableWarning
-        >
-          {alt}
-        </Caption>
-      </div>
+      <ImageComponent
+        onKeyDown={this.handleKeyDown(props)}
+        onBlur={this.handleBlur(props)}
+        onSelect={this.handleSelect(props)}
+        {...props}
+      />
     );
   };
 
@@ -320,8 +348,13 @@ export default class Image extends Node {
           return false;
         }
 
-        downloadImageNode(node);
+        const image = await fetch(node.attrs.src);
+        const imageBlob = await image.blob();
+        const imageUrl = URL.createObjectURL(imageBlob);
+        const extension = imageBlob.type.split("/")[1];
+        const fileName = node.attrs.alt || "image";
 
+        download(imageUrl, `${fileName}.${extension}`);
         return true;
       },
       deleteImage: () => (state, dispatch) => {


### PR DESCRIPTION
By downloading the image once and caching it in memory it allows for the download button to work with signed download urls that have an inbuilt expiry time (eg AWS).

Previously the download button would always re-fetch which meant if the doc had been open longer than the url expiry it would fail.

closes outline/outline#2185