### PR TITLE
fix: Improve handling of checkbox-like data

### DIFF
--- a/src/lib/markdown/checkboxes.ts
+++ b/src/lib/markdown/checkboxes.ts
@@ -3,20 +3,29 @@ import Token from "markdown-it/lib/token";
 
 const CHECKBOX_REGEX = /\[(X|\s|_|-)\]\s(.*)?/i;
 
-function matches(token: Token) {
-  return token.content.match(CHECKBOX_REGEX);
+function matches(token: Token | void) {
+  return token && token.content.match(CHECKBOX_REGEX);
 }
 
-function isInline(token: Token): boolean {
-  return token.type === "inline";
+function isInline(token: Token | void): boolean {
+  return !!token && token.type === "inline";
 }
-function isParagraph(token: Token): boolean {
-  return token.type === "paragraph_open";
+
+function isParagraph(token: Token | void): boolean {
+  return !!token && token.type === "paragraph_open";
+}
+
+function isListItem(token: Token | void): boolean {
+  return (
+    !!token &&
+    (token.type === "list_item_open" || token.type === "checkbox_item_open")
+  );
 }
 
 function looksLikeChecklist(tokens: Token[], index: number) {
   return (
     isInline(tokens[index]) &&
+    isListItem(tokens[index - 2]) &&
     isParagraph(tokens[index - 1]) &&
     matches(tokens[index])
   );

--- a/src/plugins/MarkdownPaste.ts
+++ b/src/plugins/MarkdownPaste.ts
@@ -5,6 +5,23 @@ import Extension from "../lib/Extension";
 import isUrl from "../lib/isUrl";
 import isInCode from "../queries/isInCode";
 
+/**
+ * Add support for additional syntax that users paste even though it isn't
+ * supported by the markdown parser directly by massaging the text content.
+ *
+ * @param text The incoming pasted plain text
+ */
+function normalizePastedMarkdown(text: string): string {
+  // find checkboxes not contained in a list and wrap them in list items
+  const CHECKBOX_REGEX = /^\s?(\[(X|\s|_|-)\]\s(.*)?)/gim;
+
+  while (text.match(CHECKBOX_REGEX)) {
+    text = text.replace(CHECKBOX_REGEX, match => `- ${match.trim()}`);
+  }
+
+  return text;
+}
+
 export default class MarkdownPaste extends Extension {
   get name() {
     return "markdown-paste";
@@ -83,7 +100,9 @@ export default class MarkdownPaste extends Extension {
 
             // If we've gotten this far then treat the plain text content of the
             // clipboard as possible markdown and use the parser
-            const paste = this.editor.parser.parse(text);
+            const paste = this.editor.parser.parse(
+              normalizePastedMarkdown(text)
+            );
             const slice = paste.slice(0);
 
             const transaction = view.state.tr.replaceSelection(slice);


### PR DESCRIPTION
Handles multiple situations where pasting data that looks like a checkbox `[ ]` could cause the editor to error.

closes #475 