### PR TITLE
feat: render method is not arrow function

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -768,7 +768,7 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
         </ThemeProvider>
       </Flex>
     );
-  };
+  }
 }
 
 const StyledEditor = styled("div")<{

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -689,7 +689,7 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
     }
   );
 
-  render = () => {
+  render() {
     const {
       dir,
       readOnly,


### PR DESCRIPTION
change `render = () => {}` to `render() {}`, is able to **Inheritance Inversion** Editor, just like in this way

```ts
const withStick = (WrappedComponent: React.ComponentClass<any>) => {
  return class WithStickBarEditor extends WrappedComponent {
    constructor (props) {
      super(props)
    }

    render() {
      return (
        <>
          {
            this.view && <StickBlockMenu
            view={this.view}
            commands={this.commands}
            dictionary={this.dictionary(this.props.dictionary)}
            rtl={this.state.isRTL}
            onClose={this.handleCloseBlockMenu}
            uploadImage={this.props.uploadImage}
            onLinkToolbarOpen={this.handleOpenLinkMenu}
            onImageUploadStart={this.props.onImageUploadStart}
            onImageUploadStop={this.props.onImageUploadStop}
            onShowToast={this.props.onShowToast}
          />
          }
          {super.render()}
        </>
      )
    }
  }
}
```

`const StickEditor = withStick(Editor)`

![rime-hoc](https://user-images.githubusercontent.com/6839576/126440710-4ec9f002-f0dd-47f7-bc3f-4c83de1566d3.gif)

demo code is in https://github.com/JiangWeixian/rich-markdown-editor/tree/ext
