### PR TITLE
fix: The editor interprets links without any marks

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -195,6 +195,7 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
   schema: Schema;
   serializer: MarkdownSerializer;
   parser: MarkdownParser;
+  pasteParser: MarkdownParser;
   plugins: Plugin[];
   keymaps: Plugin[];
   inputRules: InputRule[];
@@ -286,6 +287,7 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
     this.keymaps = this.createKeymaps();
     this.serializer = this.createSerializer();
     this.parser = this.createParser();
+    this.pasteParser = this.createPasteParser();
     this.inputRules = this.createInputRules();
     this.nodeViews = this.createNodeViews();
     this.view = this.createView();
@@ -461,6 +463,14 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
   createParser() {
     return this.extensions.parser({
       schema: this.schema,
+      rules: {},
+    });
+  }
+
+  createPasteParser() {
+    return this.extensions.parser({
+      schema: this.schema,
+      rules: { linkify: true },
     });
   }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -463,7 +463,6 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
   createParser() {
     return this.extensions.parser({
       schema: this.schema,
-      rules: {},
     });
   }
 

--- a/src/lib/ExtensionManager.ts
+++ b/src/lib/ExtensionManager.ts
@@ -59,7 +59,13 @@ export default class ExtensionManager {
     return new MarkdownSerializer(nodes, marks);
   }
 
-  parser({ schema, rules }) {
+  parser({
+    schema,
+    rules,
+  }: {
+    schema: any;
+    rules?: Record<string, any>;
+  }): MarkdownParser {
     const tokens: Record<string, any> = this.extensions
       .filter(
         extension => extension.type === "mark" || extension.type === "node"

--- a/src/lib/ExtensionManager.ts
+++ b/src/lib/ExtensionManager.ts
@@ -59,7 +59,7 @@ export default class ExtensionManager {
     return new MarkdownSerializer(nodes, marks);
   }
 
-  parser({ schema }) {
+  parser({ schema, rules }) {
     const tokens: Record<string, any> = this.extensions
       .filter(
         extension => extension.type === "mark" || extension.type === "node"
@@ -76,7 +76,7 @@ export default class ExtensionManager {
 
     return new MarkdownParser(
       schema,
-      makeRules({ embeds: this.embeds }),
+      makeRules({ embeds: this.embeds, rules }),
       tokens
     );
   }

--- a/src/lib/markdown/rules.ts
+++ b/src/lib/markdown/rules.ts
@@ -7,11 +7,12 @@ import tablesPlugin from "./tables";
 import noticesPlugin from "./notices";
 import underlinesPlugin from "./underlines";
 
-export default function rules({ embeds }) {
+export default function rules({ embeds, rules = {} }) {
   return markdownit("default", {
     breaks: false,
     html: false,
-    linkify: true,
+    linkify: false,
+    ...rules,
   })
     .use(embedsPlugin(embeds))
     .use(breakPlugin)

--- a/src/plugins/PasteHandler.ts
+++ b/src/plugins/PasteHandler.ts
@@ -133,7 +133,7 @@ export default class PasteHandler extends Extension {
             ) {
               event.preventDefault();
 
-              const paste = this.editor.parser.parse(
+              const paste = this.editor.pasteParser.parse(
                 normalizePastedMarkdown(text)
               );
               const slice = paste.slice(0);


### PR DESCRIPTION
Unfortunately this requires us to have a separate serializer for pasting, as we want to retain this behavior when pasting plain text and the rules are provided on initialization of the parser, not at parse-time.

closes #513