### PR TITLE
feat: add hotkey ctrl+shift+` for converting current block to notice …

### DIFF
--- a/src/menus/formatting.ts
+++ b/src/menus/formatting.ts
@@ -11,6 +11,7 @@ import {
   TodoListIcon,
   InputIcon,
   HighlightIcon,
+  InfoIcon
 } from "outline-icons";
 import { isInTable } from "prosemirror-tables";
 import { EditorState } from "prosemirror-state";
@@ -123,6 +124,18 @@ export default function formattingMenuItems(
     },
     {
       name: "separator",
+    },
+    {
+      name: "container_notice",
+      tooltip: dictionary.infoNotice,
+      icon: InfoIcon,
+      active: isNodeActive(schema.node.container_notice),
+      attrs: { style: "info" },
+      visible: allowBlocks,
+    },
+    {
+      name: "separator",
+      visible: allowBlocks,
     },
     {
       name: "link",

--- a/src/nodes/Notice.tsx
+++ b/src/nodes/Notice.tsx
@@ -89,6 +89,12 @@ export default class Notice extends Node {
     return attrs => toggleWrap(type, attrs);
   }
 
+  keys({ type, schema }) {
+    return {
+      "Shift-Ctrl-`": toggleWrap(type, schema.nodes.container_notice),
+    };
+  }
+
   handleStyleChange = event => {
     const { view } = this.editor;
     const { tr } = view.state;


### PR DESCRIPTION
Our customers ask a lot of ability to set part of the text as a notice block. The currently available way to do it is to add an extra line before the text that you need to convert and select block type from /-menu.

I've added hotkey  ctrl+shift+` and one extra item to the formatting menu.

And offer you to consider this code.
