### PR TITLE
feat: implemented the possibility to add extra commands into the Block menu from extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,33 @@ When set enforces a maximum character length on the document, not including mark
 #### `extensions`
 
 Allows additional [Prosemirror plugins](https://prosemirror.net/docs/ref/#state.Plugin_System) to be passed to the underlying Prosemirror instance.
+Also, you can add extra commands into the Block menu:
+```javascript
+class DemoExtension extends Extension {
+  get name(): string {
+    return "demo";
+  }
+
+  get menuItems(): MenuItem[] {
+    return [
+      {
+        name: "demo",
+        title: "Demo button",
+        keywords: "Demo keywords",
+        icon: DemoIcon,
+        attrs: { type: 1 },
+      },
+    ];
+  }
+
+  commands() {
+    return attr => {
+      console.log("Demo action", attr);
+      return () => null;
+    };
+  }
+}
+```
 
 #### `disableExtensions`
 

--- a/src/components/CommandMenu.tsx
+++ b/src/components/CommandMenu.tsx
@@ -11,6 +11,7 @@ import getDataTransferFiles from "../lib/getDataTransferFiles";
 import filterExcessSeparators from "../lib/filterExcessSeparators";
 import insertFiles from "../commands/insertFiles";
 import baseDictionary from "../dictionary";
+import { Extension } from "../index";
 
 const SSR = typeof window === "undefined";
 
@@ -36,6 +37,7 @@ export type Props<T extends MenuItem = MenuItem> = {
   onClose: () => void;
   onClearSearch: () => void;
   embeds?: EmbedDescriptor[];
+  extensions?: Extension[];
   renderMenuItem: (
     item: T,
     index: number,
@@ -398,9 +400,11 @@ class CommandMenu<T = MenuItem> extends React.Component<Props<T>, State> {
       uploadImage,
       commands,
       filterable = true,
+      extensions,
     } = this.props;
     let items: (EmbedDescriptor | MenuItem)[] = this.props.items;
     const embedItems: EmbedDescriptor[] = [];
+    const extensionsItems: MenuItem[] = [];
 
     for (const embed of embeds) {
       if (embed.title && embed.icon) {
@@ -411,11 +415,24 @@ class CommandMenu<T = MenuItem> extends React.Component<Props<T>, State> {
       }
     }
 
+    for (const extension of extensions || []) {
+      extensionsItems.push(...extension.menuItems);
+    }
+
     if (embedItems.length) {
       items.push({
         name: "separator",
       });
       items = items.concat(embedItems);
+    }
+
+    if (extensionsItems.length) {
+      items.push(
+        {
+          name: "separator",
+        },
+        ...extensionsItems
+      );
     }
 
     const filtered = items.filter(item => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -810,6 +810,7 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
                   onImageUploadStop={this.props.onImageUploadStop}
                   onShowToast={this.props.onShowToast}
                   embeds={this.props.embeds}
+                  extensions={this.props.extensions}
                 />
               </React.Fragment>
             )}

--- a/src/lib/Extension.ts
+++ b/src/lib/Extension.ts
@@ -3,6 +3,7 @@ import { InputRule } from "prosemirror-inputrules";
 import { Plugin } from "prosemirror-state";
 import Editor from "../";
 import { PluginSimple } from "markdown-it";
+import { MenuItem } from "../types";
 
 type Command = (attrs) => (state, dispatch) => any;
 
@@ -47,6 +48,10 @@ export default class Extension {
 
   commands(options): Record<string, Command> | Command {
     return attrs => () => false;
+  }
+
+  get menuItems(): MenuItem[] {
+    return [];
   }
 
   get defaultOptions() {


### PR DESCRIPTION
There are a lot of cases when need to add extra commands into the block menu, like adding snippets/templates or when you try to add new elements from extended markdown specification. At the current version, we haven't any possibility for it.