### PR TITLE
fix: prevent unwanted emoji menu in non Latin cultures

### DIFF
--- a/src/plugins/EmojiTrigger.tsx
+++ b/src/plugins/EmojiTrigger.tsx
@@ -4,8 +4,8 @@ import Extension from "../lib/Extension";
 import isInCode from "../queries/isInCode";
 import { run } from "./BlockMenuTrigger";
 
-const OPEN_REGEX = /(?:^|[^a-zA-Z0-9_!#$%&*@＠]):([0-9a-zA-Z_+-]+)?$/;
-const CLOSE_REGEX = /(?:^|[^a-zA-Z0-9_!#$%&*@＠]):(([0-9a-zA-Z_+-]*\s+)|(\s+[0-9a-zA-Z_+-]+)|[^0-9a-zA-Z_+-]+)$/;
+const OPEN_REGEX = /(?:^|\s):([0-9a-zA-Z_+-]+)?$/;
+const CLOSE_REGEX = /(?:^|\s):(([0-9a-zA-Z_+-]*\s+)|(\s+[0-9a-zA-Z_+-]+)|[^0-9a-zA-Z_+-]+)$/;
 
 export default class EmojiTrigger extends Extension {
   get name() {


### PR DESCRIPTION
At the current version emoji menu works correctly only in cultures with the Latin symbols because of this regexp rule /(?:^|**[^a-zA-Z0-9_!#$%&*@＠]**):([0-9a-zA-Z_+-]+)?$/ and shows it every time when you type something like that "я не хочу чтобы сейчас вылезло меню:" after that we will immediately get it.

I fixed it, please consider this pull request