### PR TITLE
fix: Emoticons converted after persistence

### DIFF
--- a/src/lib/renderToHtml.ts
+++ b/src/lib/renderToHtml.ts
@@ -7,7 +7,7 @@ import breakRule from "../rules/breaks";
 import tablesRule from "../rules/tables";
 import noticesRule from "../rules/notices";
 import underlinesRule from "../rules/underlines";
-import emojiRule from "markdown-it-emoji";
+import emojiRule from "../rules/emoji";
 
 const defaultRules = [
   embedsRule,

--- a/src/nodes/Emoji.tsx
+++ b/src/nodes/Emoji.tsx
@@ -1,7 +1,7 @@
 import { InputRule } from "prosemirror-inputrules";
 import nameToEmoji from "gemoji/name-to-emoji.json";
 import Node from "./Node";
-import emojiPlugin from "markdown-it-emoji";
+import emojiRule from "../rules/emoji";
 
 export default class Emoji extends Node {
   get name() {
@@ -54,7 +54,7 @@ export default class Emoji extends Node {
   }
 
   get rulePlugins() {
-    return [emojiPlugin];
+    return [emojiRule];
   }
 
   commands({ type }) {

--- a/src/rules/emoji.ts
+++ b/src/rules/emoji.ts
@@ -1,0 +1,9 @@
+import nameToEmoji from "gemoji/name-to-emoji.json";
+import emojiPlugin from "markdown-it-emoji";
+
+export default function emoji(md): void {
+  return emojiPlugin(md, {
+    defs: nameToEmoji,
+    shortcuts: {},
+  });
+}

--- a/src/rules/emoji.ts
+++ b/src/rules/emoji.ts
@@ -1,7 +1,8 @@
 import nameToEmoji from "gemoji/name-to-emoji.json";
+import MarkdownIt from "markdown-it";
 import emojiPlugin from "markdown-it-emoji";
 
-export default function emoji(md): void {
+export default function emoji(md: MarkdownIt): (md: MarkdownIt) => void {
   return emojiPlugin(md, {
     defs: nameToEmoji,
     shortcuts: {},


### PR DESCRIPTION
Passing the defs to match gemoji exactly may also reduce filesize as it will be using the gemoji data rather than the one bundled inside of `markdown-it-emoji`.

This also removes any chance of disconnect between these two datasets.

closes outline/outline#2785