### PR TITLE
fix: emoji highlight behavior

### DIFF
--- a/src/components/CommandMenu.tsx
+++ b/src/components/CommandMenu.tsx
@@ -299,9 +299,11 @@ class CommandMenu<T = MenuItem> extends React.Component<Props<T>, State> {
   };
 
   insertBlock(item) {
+    console.log({ item });
     this.clearSearch();
 
     const command = this.props.commands[item.name];
+
     if (command) {
       command(item.attrs);
     } else {

--- a/src/components/CommandMenu.tsx
+++ b/src/components/CommandMenu.tsx
@@ -299,7 +299,6 @@ class CommandMenu<T = MenuItem> extends React.Component<Props<T>, State> {
   };
 
   insertBlock(item) {
-    console.log({ item });
     this.clearSearch();
 
     const command = this.props.commands[item.name];

--- a/src/nodes/Emoji.tsx
+++ b/src/nodes/Emoji.tsx
@@ -22,8 +22,8 @@ export default class Emoji extends Node {
       content: "text*",
       marks: "",
       group: "inline",
-      selectable: true,
-      draggable: true,
+      selectable: false,
+      draggable: false,
       parseDOM: [
         {
           tag: "span.emoji",

--- a/src/nodes/Emoji.tsx
+++ b/src/nodes/Emoji.tsx
@@ -23,7 +23,6 @@ export default class Emoji extends Node {
       marks: "",
       group: "inline",
       selectable: false,
-      draggable: false,
       parseDOM: [
         {
           tag: "span.emoji",


### PR DESCRIPTION
https://www.loom.com/share/5780df97a76b487f869dedf3a1e90274

I don't know the ins and outs of prosemirror super well, but these simple config changes seem to fix the issue while behaving correctly in other conceivable ways

the best scenario would be for the emoji picker to just write the emoji text and not put a new node type into the mix but I think that would require deeper surgery